### PR TITLE
Обход ошибки

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -11,4 +11,4 @@ dd if=boot.bin of=x16pros.img conv=notrunc
 dd if=kernel.bin of=x16pros.img bs=512 seek=1 conv=notrunc
 echo "Done."
 
-qemu-system-i386 -hda disk_img/x16pros.img
+qemu-system-i386 -hda x16pros.img


### PR DESCRIPTION
Согласно коду после компиляции проекта должен запуститься эмулятор qemu по пути "_disk_img/x16pros.img_". Папки "disk_img" нет и она не создаётся. Для неопытных/новичков будет трудновато узнать почему эта "ОС" не запускается, а всего лишь надо убрать `disk_img/`.