### PR TITLE
ci: upload build artifacts; add manual trigger and concurrency

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: Build and Test x16-PRos
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- Uploads build artifacts (x16pros.img, BOOT.BIN, KERNEL.BIN, SHA256SUMS)
- Adds manual trigger (workflow_dispatch)
- Adds concurrency (cancel in-progress for same ref)
- Hardens steps with set -euxo pipefail
