### PR TITLE
ci: add Release workflow (tags → GitHub Release with artifacts)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: Build and Test x16-PRos
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install deps
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y nasm mtools dosfstools
+
+      - name: Build
+        run: |
+          set -euxo pipefail
+          chmod +x build.sh
+          ./build.sh
+
+      - name: Prepare artifacts
+        run: |
+          set -euxo pipefail
+          mkdir -p out
+          cp disk_img/x16pros.img out/x16pros.img
+          cp bin/BOOT.BIN out/BOOT.BIN
+          cp bin/KERNEL.BIN out/KERNEL.BIN
+          (cd out && sha256sum x16pros.img BOOT.BIN KERNEL.BIN > SHA256SUMS)
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            out/x16pros.img
+            out/BOOT.BIN
+            out/KERNEL.BIN
+            out/SHA256SUMS


### PR DESCRIPTION
- Publishes GitHub Release on tag push (vX.Y.Z)
- Builds with nasm/mtools/dosfstools
- Uploads artifacts: x16pros.img, BOOT.BIN, KERNEL.BIN, SHA256SUMS
- Generates release notes

*[depends on #29, please merge that first](https://github.com/PRoX2011/x16-PRos/pull/29l)*