### PR TITLE
chore(build): add disk_img to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bin/
 
 # Common build directories
 build*/
+disk_img/
 
 # Visual Studio Code
 .vscode/


### PR DESCRIPTION
This PR adds the disk_img/ directory to .gitignore to prevent build artifacts from being tracked by Git