### PR TITLE
Implement Ne2000 driver, IP, ARP, ICMP. Edit programs/help.asm.

### DIFF
--- a/programs/help.asm
+++ b/programs/help.asm
@@ -109,7 +109,7 @@ string_move_cursor:
     ret
 
 help_categories:
-    dw  help_menu_1, help_menu_2, help_menu_3, help_menu_4, help_menu_5
+    dw  help_menu_1, help_menu_2, help_menu_3, help_menu_4, help_menu_5, help_menu_6
     dw 0
 
 current_category dw 0
@@ -212,6 +212,28 @@ help_menu_5 db 0xC9, 18 dup(0xCD), ' PRos help ', 18 dup(0xCD), 0xBB, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, 47 dup(0xC4), 0xBA, 10, 13
+     db 0xBA, ' <-- Back   |  Press ESC to exit   |  Next --> ', 0xBA, 10, 13
+     db 0xC8, 47 dup(0xCD), 0xBC, 0
+
+help_menu_6 db 0xC9, 18 dup(0xCD), ' PRos help ', 18 dup(0xCD), 0xBB, 10, 13
+     db 0xBA, ' Networking operations                   [6/6] ', 0xBA, 10, 13
+     db 0xBA, 47 dup(0xC4), 0xBA, 10, 13
+     db 0xBA, '  ip               - show current IP           ', 0xBA, 10, 13
+     db 0xBA, '  setip <IPv4>     - set own static IP address ', 0xBA, 10, 13
+     db 0xBA, '  ping <IPv4 Addr> - ping a target             ', 0xBA, 10, 13
+     db 0xBA, '  netinfo          - show interface info       ', 0xBA, 10, 13
+     db 0xBA, '                                               ', 0xBA, 10, 13
+     db 0xBA, '  Example: ping 10.0.2.2                       ', 0xBA, 10, 13
+     db 0xBA, '  setip 10.0.2.5                               ', 0xBA, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13
      db 0xBA, '                                               ', 0xBA, 10, 13

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -27,4 +27,4 @@ qemu-system-x86_64 \
     -device adlib,audiodev=snd0 \
     -audiodev pa,id=snd0 \
     -drive format=raw,file=FLOPPY2.img,if=floppy,index=1 \
-    -parallel file:lpt/output.txt
+    -device ne2k_isa,netdev=net0 -netdev user,id=net0

--- a/src/drivers/net/ne2000/ne2000.asm
+++ b/src/drivers/net/ne2000/ne2000.asm
@@ -1,0 +1,712 @@
+BITS 16
+section .text
+
+CR_STP      equ  0x01
+CR_STA      equ  0x02
+CR_TXP      equ  0x04
+CR_RD_RD    equ  0x08
+CR_RD_WR    equ  0x10
+CR_NODMA    equ  0x20
+CR_PG0      equ  0x00
+CR_PG1      equ  0x40
+CR_PG2      equ  0x80
+
+CR_PG0_STP  equ  CR_PG0 | CR_NODMA | CR_STP    ; 0x21
+CR_PG0_STA  equ  CR_PG0 | CR_NODMA | CR_STA    ; 0x22
+CR_PG1_STP  equ  CR_PG1 | CR_NODMA | CR_STP    ; 0x61
+CR_PG1_STA  equ  CR_PG1 | CR_NODMA | CR_STA    ; 0x62
+CR_DMA_WR   equ  CR_PG0 | CR_RD_WR | CR_STA    ; 0x12
+CR_DMA_RD   equ  CR_PG0 | CR_RD_RD | CR_STA    ; 0x0A
+
+ISR_PRX     equ  0x01
+ISR_PTX     equ  0x02
+ISR_RXE     equ  0x04
+ISR_TXE     equ  0x08
+ISR_OVW     equ  0x10
+ISR_CNT     equ  0x20
+ISR_RDC     equ  0x40
+ISR_RST     equ  0x80
+
+DCR_INIT      equ  0x49   ; 16-bit DMA, 80x86 byte order, 16-byte FIFO
+RCR_MONITOR   equ  0x20
+RCR_NORMAL    equ  0x04
+TCR_NORMAL    equ  0x00
+TCR_LOOPBACK  equ  0x02
+
+TX_PAGE     equ  0x40
+RX_PSTART   equ  0x46
+RX_PSTOP    equ  0x80
+
+ne2000_init:
+        push    bx
+        push    cx
+        push    si
+
+        mov     [ne2k_iobase], ax
+        mov     [ne2k_irq],    bl
+
+        mov     dx, ax
+        add     dx, 0x1F        ; Reset port
+        in      al, dx          ; Any read/write resets the card
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     cx, 0x200
+.init_wait_rst:
+        in      al, dx
+        test    al, ISR_RST
+        jnz     .init_rst_ok
+        loop    .init_wait_rst
+        stc
+        jmp     .init_exit
+
+.init_rst_ok:
+        mov     al, 0xFF
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0_STP
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0E        ; DCR (Data Configuration Register)
+        mov     al, DCR_INIT    ; 0x49 = 16-bit DMA, normal loopback, 8-byte FIFO
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0A
+        xor     al, al
+        out     dx, al
+        inc     dx
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0F
+        xor     al, al
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, 0xFF
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0C
+        mov     al, RCR_MONITOR
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0D
+        mov     al, TCR_LOOPBACK
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x04
+        mov     al, TX_PAGE
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x01
+        mov     al, RX_PSTART
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x02
+        mov     al, RX_PSTOP
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x03
+        mov     al, RX_PSTOP - 1
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0A
+        mov     al, 32
+        out     dx, al
+        inc     dx
+        xor     al, al
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x08
+        xor     al, al
+        out     dx, al
+        inc     dx
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_DMA_RD
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x10
+        lea     si, [ne2k_prom]
+        mov     cx, 16
+.init_prom_loop:
+        in      ax, dx
+        mov     [si],     al
+        mov     [si + 1], ah
+        add     si, 2
+        loop    .init_prom_loop
+
+        ; Wait for RDC.
+        ; Same reasoning as RST poll — 0x200 is ample for QEMU/real hardware.
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     cx, 0x200
+.init_prom_rdc_wait:
+        in      al, dx
+        test    al, ISR_RDC
+        jnz     .init_prom_rdc_done
+        loop    .init_prom_rdc_wait
+        stc
+        jmp     .init_exit
+
+.init_prom_rdc_done:
+        mov     al, ISR_RDC
+        out     dx, al
+
+        lea     si, [ne2k_prom]
+        cmp     byte [si + 14], 0x57
+        je      .init_sig_ok
+        cmp     byte [si + 14], 0xFF
+        je      .init_bad_sig
+        
+        ; Not 0x57, but not 0xFF either — maybe it is an NE2000 clone
+        jmp     .init_sig_ok
+
+.init_bad_sig:
+        stc
+        jmp     .init_exit
+
+.init_sig_ok:
+        lea     si, [ne2k_prom]
+        lea     bx, [ne2k_mac]
+
+        mov     al, [si]
+        cmp     al, [si + 1]
+        je      .mac_doubled
+
+        mov     cx, 6
+.mac_plain:
+        mov     al, [si]
+        mov     [bx], al
+        inc     si
+        inc     bx
+        loop    .mac_plain
+        jmp     .mac_extracted
+
+.mac_doubled:
+        mov     cx, 6
+.mac_doubled_loop:
+        mov     al, [si]
+        mov     [bx], al
+        add     si, 2
+        inc     bx
+        loop    .mac_doubled_loop
+
+.mac_extracted:
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG1_STP
+        out     dx, al
+
+        mov     bx, [ne2k_iobase]
+        lea     si, [ne2k_mac]
+        mov     cx, 6
+.par_loop:
+        inc     bx
+        mov     dx, bx
+        mov     al, [si]
+        out     dx, al
+        inc     si
+        loop    .par_loop
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, RX_PSTART
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x08
+        mov     cx, 8
+.mar_loop:
+        mov     al, 0xFF
+        out     dx, al
+        inc     dx
+        loop    .mar_loop
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0_STP
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x03
+        mov     al, RX_PSTART
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0C
+        mov     al, RCR_NORMAL
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0D
+        mov     al, TCR_NORMAL
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, 0xFF
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0F
+        mov     al, ISR_PRX | ISR_PTX | ISR_RXE | ISR_TXE | ISR_OVW
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0_STA
+        out     dx, al
+
+        mov     byte [ne2k_rx_cur], RX_PSTART
+
+        clc
+
+.init_exit:
+        pop     si
+        pop     cx
+        pop     bx
+        ret
+
+ne2000_send:
+        push    bx
+        push    cx
+        push    si
+
+        mov     bx, cx
+
+        mov     dx, [ne2k_iobase]
+        mov     cx, 0x4000
+.send_busy_wait:
+        in      al, dx
+        test    al, CR_TXP
+        jz      .send_not_busy
+        loop    .send_busy_wait
+        stc
+        jmp     .send_exit
+
+.send_not_busy:
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0A
+        mov     al, bl
+        out     dx, al
+        inc     dx
+        mov     al, bh
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, ISR_RDC
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x08
+        xor     al, al
+        out     dx, al
+        inc     dx
+        mov     al, TX_PAGE
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_DMA_WR
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x10
+        mov     cx, bx
+        shr     cx, 1
+        jz      .send_odd_byte
+
+.send_word_loop:
+        lodsw
+        out     dx, ax
+        loop    .send_word_loop
+
+.send_odd_byte:
+        test    bx, 1
+        jz      .send_dma_done
+        xor     ah, ah
+        lodsb
+        out     dx, ax
+
+.send_dma_done:
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     cx, 0xFFFF
+.send_rdc_wait:
+        in      al, dx
+        test    al, ISR_RDC
+        jnz     .send_rdc_done
+        loop    .send_rdc_wait
+        stc
+        jmp     .send_exit
+
+.send_rdc_done:
+        mov     al, ISR_RDC
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x04
+        mov     al, TX_PAGE
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x05
+        mov     al, bl
+        out     dx, al
+        inc     dx
+        mov     al, bh
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0 | CR_NODMA | CR_STA | CR_TXP
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     cx, 0xFFFF
+.send_tx_wait:
+        in      al, dx
+        test    al, ISR_PTX | ISR_TXE
+        jnz     .send_tx_done
+        loop    .send_tx_wait
+        stc
+        jmp     .send_exit
+
+.send_tx_done:
+        test    al, ISR_TXE
+        jnz     .send_tx_error
+
+        mov     al, ISR_PTX
+        out     dx, al
+        clc
+        jmp     .send_exit
+
+.send_tx_error:
+        mov     al, ISR_TXE
+        out     dx, al
+        stc
+
+.send_exit:
+        pop     si
+        pop     cx
+        pop     bx
+        ret
+
+ne2000_recv:
+        push    bx
+        push    si
+        push    di
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG1_STA
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        in      al, dx
+        mov     bl, al
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0_STA
+        out     dx, al
+
+        mov     al, [ne2k_rx_cur]
+        cmp     bl, al
+        je      .recv_none
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0A
+        mov     al, 4
+        out     dx, al
+        inc     dx
+        xor     al, al
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x08
+        xor     al, al
+        out     dx, al
+        inc     dx
+        mov     al, [ne2k_rx_cur]
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, ISR_RDC
+        out     dx, al
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_DMA_RD
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x10
+        in      ax, dx
+        mov     [ne2k_rx_hdr + 0], al
+        mov     [ne2k_rx_hdr + 1], ah
+        in      ax, dx
+        mov     [ne2k_rx_hdr + 2], al
+        mov     [ne2k_rx_hdr + 3], ah
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     cx, 0xFFFF
+.recv_hdr_rdc_wait:
+        in      al, dx
+        test    al, ISR_RDC
+        jnz     .recv_hdr_rdc_done
+        loop    .recv_hdr_rdc_wait
+        jmp     .recv_skip
+
+.recv_hdr_rdc_done:
+        mov     al, ISR_RDC
+        out     dx, al
+
+        mov     al, [ne2k_rx_hdr + 0]
+        test    al, 0x01
+        jz      .recv_skip
+
+        xor     bh, bh
+        mov     bl, [ne2k_rx_hdr + 2]
+        mov     bh, [ne2k_rx_hdr + 3]
+
+        cmp     bx, 18
+        jb      .recv_skip
+        cmp     bx, 1518
+        ja      .recv_skip
+
+        sub     bx, 4
+
+        xor     ah, ah
+        mov     al, [ne2k_rx_cur]
+        shl     ax, 8
+        add     ax, 4
+        add     ax, bx
+
+        cmp     ax, RX_PSTOP * 256
+        ja      .recv_two_reads
+
+        xor     ah, ah
+        mov     al, [ne2k_rx_cur]
+        shl     ax, 8
+        add     ax, 4
+        mov     cx, bx
+        call    ne2k_dma_read
+        jmp     .recv_update_bnry
+
+.recv_two_reads:
+        xor     ah, ah
+        mov     al, [ne2k_rx_cur]
+        mov     si, RX_PSTOP
+        sub     si, ax
+        shl     si, 8
+        sub     si, 4
+
+        shl     ax, 8
+        add     ax, 4
+        mov     cx, si
+        call    ne2k_dma_read
+
+        mov     cx, bx
+        sub     cx, si
+        mov     ax, RX_PSTART * 256
+        call    ne2k_dma_read
+
+.recv_update_bnry:
+        mov     al, [ne2k_rx_hdr + 1]
+        mov     [ne2k_rx_cur], al
+
+        dec     al
+        cmp     al, RX_PSTART
+        jae     .recv_bnry_ok
+        mov     al, RX_PSTOP - 1
+.recv_bnry_ok:
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x03
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, ISR_PRX
+        out     dx, al
+
+        mov     cx, bx
+        clc
+        jmp     .recv_exit
+
+.recv_skip:
+        mov     al, [ne2k_rx_hdr + 1]
+        cmp     al, RX_PSTART
+        jb      .recv_skip_advance_one
+        cmp     al, RX_PSTOP
+        jb      .recv_skip_use_next
+.recv_skip_advance_one:
+        mov     al, [ne2k_rx_cur]
+        inc     al
+        cmp     al, RX_PSTOP
+        jb      .recv_skip_use_next
+        mov     al, RX_PSTART
+.recv_skip_use_next:
+        mov     [ne2k_rx_cur], al
+        dec     al
+        cmp     al, RX_PSTART
+        jae     .recv_skip_bnry_ok
+        mov     al, RX_PSTOP - 1
+.recv_skip_bnry_ok:
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x03
+        out     dx, al
+
+.recv_none:
+        stc
+
+.recv_exit:
+        pop     di
+        pop     si
+        pop     bx
+        ret
+
+ne2000_irq:
+        push    dx
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_PG0_STA
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        in      al, dx
+        out     dx, al
+
+        pop     dx
+        ret
+
+ne2k_dma_read:
+        push    si
+
+        push    ax
+        push    cx
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        mov     al, ISR_RDC
+        out     dx, al
+        pop     cx
+        pop     ax
+
+        push    ax
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x0A
+        mov     al, cl
+        out     dx, al
+        inc     dx
+        mov     al, ch
+        out     dx, al
+        pop     ax
+
+        push    ax
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x08
+        out     dx, al
+        inc     dx
+        mov     al, ah
+        out     dx, al
+        pop     ax
+
+        mov     dx, [ne2k_iobase]
+        mov     al, CR_DMA_RD
+        out     dx, al
+
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x10
+
+        push    cx
+        shr     cx, 1
+        jz      .dma_rd_trailing
+
+.dma_rd_word_loop:
+        in      ax, dx
+        stosw
+        loop    .dma_rd_word_loop
+
+.dma_rd_trailing:
+        pop     cx
+        test    cx, 1
+        jz      .dma_rd_poll
+
+        in      ax, dx
+        stosb
+
+.dma_rd_poll:
+        mov     dx, [ne2k_iobase]
+        add     dx, 0x07
+        push    cx
+        mov     cx, 0xFFFF
+.dma_rd_rdc_wait:
+        in      al, dx
+        test    al, ISR_RDC
+        jnz     .dma_rd_rdc_done
+        loop    .dma_rd_rdc_wait
+.dma_rd_rdc_done:
+        mov     al, ISR_RDC
+        out     dx, al
+        pop     cx
+
+        pop     si
+        ret
+
+ne2000_probe:
+        push    si
+        push    bx
+
+        lea     si, [ne2k_probe_ports]
+
+.probe_loop:
+        mov     ax, [si]
+        test    ax, ax
+        jz      .probe_fail
+
+        ; Try IRQ 9 (common for QEMU/PCI ne2000 clones) then 3
+        mov     bl, 9
+        call    ne2000_init
+        jnc     .probe_ok
+
+        mov     bl, 3
+        call    ne2000_init
+        jnc     .probe_ok
+
+        add     si, 2
+        jmp     .probe_loop
+
+.probe_ok:
+        clc
+        pop     bx
+        pop     si
+        ret
+
+.probe_fail:
+        stc
+        pop     bx
+        pop     si
+        ret
+
+section .data
+
+ne2k_iobase       dw  0x0000
+ne2k_irq          db  0x00
+ne2k_mac          db  0, 0, 0, 0, 0, 0
+ne2k_rx_cur       db  RX_PSTART
+ne2k_rx_hdr       db  0, 0, 0, 0
+ne2k_prom         times 32 db 0
+ne2k_probe_ports  dw  0x300, 0x240, 0x280, 0x2C0, 0x320, 0x340, 0x360, 0x0000

--- a/src/kernel/InternetProtocol/arp.asm
+++ b/src/kernel/InternetProtocol/arp.asm
@@ -1,0 +1,153 @@
+; ==============================================================================
+;  ARP Implementation (Address Resolution Protocol)
+; ==============================================================================
+
+BITS 16
+
+; ARP Packet Structure
+ARP_HW_TYPE     equ 0   ; 2 bytes
+ARP_PROTO_TYPE  equ 2   ; 2 bytes
+ARP_HW_LEN      equ 4   ; 1 byte
+ARP_PROTO_LEN   equ 5   ; 1 byte
+ARP_OPCODE      equ 6   ; 2 bytes
+ARP_SENDER_MAC  equ 8   ; 6 bytes
+ARP_SENDER_IP   equ 14  ; 4 bytes
+ARP_TARGET_MAC  equ 18  ; 6 bytes
+ARP_TARGET_IP   equ 24  ; 4 bytes
+ARP_SIZE        equ 28
+
+; ARP Opcodes
+ARP_OP_REQUEST  equ 1
+ARP_OP_REPLY    equ 2
+
+section .data
+    arp_target_ip_cache   times 4 db 0
+    arp_target_mac_cache  times 6 db 0
+    arp_resolved          db 0
+
+section .text
+
+; ------------------------------------------------------------------------------
+; arp_send_request
+; IN:  DS:SI = Target IP (4 bytes)
+; ------------------------------------------------------------------------------
+arp_send_request:
+    pusha
+    push ds
+    pop es
+    
+    ; Save target IP for comparison
+    mov di, arp_target_ip_cache
+    mov cx, 4
+    rep movsb
+    
+    mov byte [arp_resolved], 0
+    
+    ; Construct Packet in disk_buffer
+    mov di, disk_buffer
+    
+    ; --- Ethernet Header ---
+    ; Destination MAC: Broadcast (FF:FF:FF:FF:FF:FF)
+    mov al, 0xFF
+    mov cx, 6
+    rep stosb
+    
+    ; Source MAC: Our MAC
+    lea si, [ne2k_mac]
+    mov cx, 6
+    rep movsb
+    
+    ; Type: ARP (0x0806) -> 0x0608 Big Endian
+    mov ax, 0x0608
+    stosw
+    
+    ; --- ARP Body ---
+    mov ax, 0x0100 ; HW: Ethernet (1)
+    stosw
+    mov ax, 0x0008 ; Proto: IP (0x0800)
+    stosw
+    mov al, 6      ; HW Len
+    stosb
+    mov al, 4      ; Proto Len
+    stosb
+    mov ax, 0x0100 ; Opcode: Request (1)
+    stosw
+    
+    ; Sender MAC
+    lea si, [ne2k_mac]
+    mov cx, 6
+    rep movsb
+    
+    ; Sender IP
+    lea si, [net_local_ip]
+    mov cx, 4
+    rep movsb
+    
+    ; Target MAC (0 for request)
+    xor al, al
+    mov cx, 6
+    rep stosb
+    
+    ; Target IP
+    lea si, [arp_target_ip_cache]
+    mov cx, 4
+    rep movsb
+    
+    ; Send Packet (min 60 bytes)
+    mov si, disk_buffer
+    mov cx, 60
+    call ne2000_send
+    
+    popa
+    ret
+
+; ------------------------------------------------------------------------------
+; arp_handle_packet
+; IN:  DS:SI = Packet (starting at Ethernet Header)
+; ------------------------------------------------------------------------------
+arp_handle_packet:
+    pusha
+    
+    ; Check if Type is ARP (offset 12)
+    cmp word [si + 12], 0x0608
+    jne .done
+    
+    ; Move to ARP Body (offset 14)
+    add si, 14
+    
+    ; Check Opcode: Reply (2) -> 0x0200
+    cmp word [si + ARP_OPCODE], 0x0200
+    jne .check_request
+    
+    ; Is it replying to our pending IP?
+    lea di, [si + ARP_SENDER_IP]
+    lea bx, [arp_target_ip_cache]
+    mov cx, 4
+.check_reply_ip:
+    mov al, [bx]
+    cmp al, [di]
+    jne .done
+    inc bx
+    inc di
+    loop .check_reply_ip
+    
+    ; Found our MAC!
+    mov di, arp_target_mac_cache
+    lea bx, [si + ARP_SENDER_MAC]
+    mov cx, 6
+.copy_mac:
+    mov al, [bx]
+    mov [di], al
+    inc bx
+    inc di
+    loop .copy_mac
+    
+    mov byte [arp_resolved], 1
+    jmp .done
+
+.check_request:
+    ; ... (Optional: reply to others' requests)
+
+.done:
+    popa
+    ret

--- a/src/kernel/InternetProtocol/icmp.asm
+++ b/src/kernel/InternetProtocol/icmp.asm
@@ -1,0 +1,298 @@
+; ==============================================================================
+;  ICMP Implementation (Internet Control Message Protocol)
+; ==============================================================================
+
+BITS 16
+
+; ICMP Header
+ICMP_TYPE       equ 0   ; 1 byte
+ICMP_CODE       equ 1   ; 1 byte
+ICMP_CKSUM      equ 2   ; 2 bytes
+ICMP_ID         equ 4   ; 2 bytes
+ICMP_SEQ        equ 6   ; 2 bytes
+ICMP_SIZE       equ 8
+
+; ICMP Types
+ICMP_TYPE_ECHO_REPLY    equ 0
+ICMP_TYPE_ECHO_REQUEST  equ 8
+
+section .data
+    icmp_id_val     dw 0xBEEF
+    icmp_seq_val    dw 0
+    icmp_target_ip  times 4 db 0
+
+section .text
+
+; ------------------------------------------------------------------------------
+; icmp_ping
+; IN:  DS:SI = Target IP String (e.g. "10.0.2.2")
+; ------------------------------------------------------------------------------
+icmp_ping:
+    pusha
+    
+    ; Hardware check: if MAC is all 0, probe failed
+    mov bx, ne2k_mac
+    mov ax, [bx]
+    or ax, [bx+2]
+    or ax, [bx+4]
+    jnz .hw_ok
+    
+    mov si, err_msg_no_card
+    call print_string_red
+    popa
+    ret
+
+.hw_ok:
+    ; 1. Parse IP String
+    mov di, icmp_target_ip
+    call icmp_parse_ip
+    jc .error_parse
+    
+    ; Print target info
+    push si
+    mov si, msg_pinging
+    call print_string
+    pop si
+    call print_string
+    mov si, msg_newline
+    call print_string
+
+    ; 2. Check if target is our own IP (loopback)
+    lea si, [icmp_target_ip]
+    lea di, [net_local_ip]
+    mov cx, 4
+    xor bx, bx
+.check_self_ip:
+    mov al, [si]
+    cmp al, [di]
+    jne .not_self_ip
+    inc si
+    inc di
+    loop .check_self_ip
+    ; Target IP matches our IP - use our MAC directly
+    mov si, msg_resolving_arp
+    call print_string
+    mov si, msg_self_ping
+    call print_string
+    lea di, [arp_target_mac_cache]
+    lea si, [ne2k_mac]
+    mov cx, 6
+    rep movsb
+    mov byte [arp_resolved], 1
+    jmp .send_ping
+
+.not_self_ip:
+    ; 2. Resolve MAC via ARP
+    push si
+    mov si, msg_resolving_arp
+    call print_string
+    pop si
+    
+    mov si, icmp_target_ip
+    call arp_send_request
+    
+    ; Wait for ARP Reply
+    mov cx, 500
+.arp_wait:
+    push cx
+    
+    ; 10ms delay using BIOS INT 15h
+    mov ah, 0x86
+    mov cx, 0
+    mov dx, 10000 ; 10,000 us = 10 ms
+    int 0x15
+    
+    push ds
+    pop es
+    mov di, disk_buffer
+    call ne2000_recv
+    pop cx
+    jc .no_arp_packet
+    
+    ; Naive dispatcher: call arp_handle_packet
+    mov si, disk_buffer
+    call arp_handle_packet
+    cmp byte [arp_resolved], 1
+    je .send_ping
+
+.no_arp_packet:
+    ; Check keyboard for Ctrl+C
+    mov ah, 0x01
+    int 0x16
+    jz .no_key_arp
+    mov ah, 0x00
+    int 0x16
+    cmp al, 3 ; Ctrl+C
+    je .interrupted
+.no_key_arp:
+    loop .arp_wait
+    jmp .error_timeout
+
+.send_ping:
+    ; 3. Loop Pings
+    mov cx, 4 ; 4 pings
+.ping_loop:
+    push cx
+    
+    ; Construct ICMP Packet
+    mov di, disk_buffer + 200 ; Temporary buffer for ICMP payload
+    mov byte [di + ICMP_TYPE], ICMP_TYPE_ECHO_REQUEST
+    mov byte [di + ICMP_CODE], 0
+    mov word [di + ICMP_CKSUM], 0
+    mov ax, [icmp_id_val]
+    mov [di + ICMP_ID], ax
+    mov ax, [icmp_seq_val]
+    inc ax
+    mov [icmp_seq_val], ax
+    mov [di + ICMP_SEQ], ax
+    
+    ; Simple Payload
+    mov byte [di + 8], 'A'
+    mov byte [di + 9], 'B'
+    mov byte [di + 10], 'C'
+    
+    ; Calculate ICMP Checksum
+    push di
+    mov si, di
+    mov cx, 11 ; 8 header + 3 payload
+    call icmp_calc_checksum
+    pop di
+    mov [di + ICMP_CKSUM], ax
+    
+    ; Send via IP
+    mov si, di
+    mov cx, 11
+    mov al, IP_PROTO_ICMP
+    call ip_send_packet
+    
+    ; Wait for Reply
+    mov cx, 500
+.reply_wait:
+    push cx
+    push ds
+    pop es
+    mov di, disk_buffer
+    call ne2000_recv
+    pop cx
+    jc .no_packet
+    
+    ; Check if it's an ICMP Echo Reply for us
+    mov si, disk_buffer + 14 ; IP Header
+    cmp byte [si + 9], 1 ; Protocol ICMP
+    jne .no_packet
+    
+    add si, 20 ; ICMP Header
+    cmp byte [si + ICMP_TYPE], ICMP_TYPE_ECHO_REPLY
+    jne .no_packet
+    
+    ; Success!
+    mov si, msg_reply
+    call print_string
+    jmp .next_ping
+
+.no_packet:
+    ; Check keyboard
+    mov ah, 0x01
+    int 0x16
+    jz .no_key_reply
+    mov ah, 0x00
+    int 0x16
+    cmp al, 3 ; Ctrl+C
+    je .interrupted_pop
+.no_key_reply:
+    loop .reply_wait
+    mov si, msg_timeout
+    call print_string
+
+.next_ping:
+    pop cx
+    dec cx
+    jnz near .ping_loop
+    
+    popa
+    ret
+
+.interrupted_pop:
+    pop cx
+.interrupted:
+    mov si, msg_interrupted
+    call print_string
+    popa
+    ret
+
+.error_parse:
+    mov si, err_msg_parse
+    call print_string_red
+    popa
+    ret
+
+.error_timeout:
+    mov si, err_msg_timeout
+    call print_string_red
+    popa
+    ret
+
+; --- Helpers ---
+
+icmp_parse_ip:
+    pusha
+    ; Destination DI set by caller
+    xor bx, bx ; Current byte value
+    xor bh, bh ; Dot count
+.loop:
+    lodsb
+    cmp al, '.'
+    je .dot
+    cmp al, 0
+    je .end
+    cmp al, ' '
+    je .end
+    cmp al, 13 ; Carriage Return
+    je .end
+    
+    sub al, '0'
+    jb .fail
+    cmp al, 9
+    ja .fail
+    
+    mov cl, al       ; Save digit
+    mov al, bl       ; Current byte value
+    mov dl, 10
+    mul dl           ; ax = bl * 10
+    add al, cl       ; Add digit
+    mov bl, al       ; Store back
+    jmp .loop
+
+.dot:
+    mov [di], bl
+    inc di
+    xor bl, bl
+    inc bh
+    jmp .loop
+
+.end:
+    mov [di], bl
+    cmp bh, 3
+    jne .fail
+    popa
+    clc
+    ret
+
+.fail:
+    popa
+    stc
+    ret
+
+icmp_calc_checksum:
+    jmp ip_calc_checksum
+
+msg_resolving_arp  db 'Resolving MAC address...', 13, 10, 0
+msg_self_ping      db 'Loopback (self-ping)', 13, 10, 0
+msg_pinging     db 'Pinging ', 0
+msg_newline     db 13, 10, 0
+msg_reply       db 'Reply from host: bytes=32 time<1ms TTL=64', 13, 10, 0
+msg_timeout     db 'Request timed out.', 13, 10, 0
+msg_interrupted db '^C', 13, 10, 0
+err_msg_parse   db 'Bad IP.', 13, 10, 0
+err_msg_timeout db 'No ARP.', 13, 10, 0
+err_msg_no_card  db 'No NE2000 card found.', 13, 10, 0

--- a/src/kernel/InternetProtocol/ip.asm
+++ b/src/kernel/InternetProtocol/ip.asm
@@ -1,0 +1,186 @@
+; ==============================================================================
+;  IP Implementation (Internet Protocol)
+; ==============================================================================
+
+BITS 16
+
+; IP Header Structure
+IP_VHL          equ 0   ; 1 byte
+IP_TOS          equ 1   ; 1 byte
+IP_LEN          equ 2   ; 2 bytes
+IP_ID           equ 4   ; 2 bytes
+IP_FRAG         equ 6   ; 2 bytes
+IP_TTL          equ 8   ; 1 byte
+IP_PROTO        equ 9   ; 1 byte
+IP_CKSUM        equ 10  ; 2 bytes
+IP_SRC          equ 12  ; 4 bytes
+IP_DST          equ 16  ; 4 bytes
+IP_SIZE         equ 20
+
+; Protocol Types
+IP_PROTO_ICMP   equ 1
+
+section .data
+    ip_id_counter   dw 0
+
+section .text
+
+; ------------------------------------------------------------------------------
+; ip_send_packet
+; IN:  DS:SI = Payload (e.g. ICMP), CX = Payload Length, AL = Protocol
+; ------------------------------------------------------------------------------
+ip_send_packet:
+    pusha
+    
+    mov bx, cx ; Save payload length
+    mov dl, al ; Save protocol
+    
+    ; disk_buffer + 0-13: Ethernet
+    ; disk_buffer + 14-33: IP
+    ; disk_buffer + 34+: Payload
+    
+    ; --- Ethernet Header ---
+    mov di, disk_buffer
+    
+    ; Destination MAC
+    push si
+    lea si, [arp_target_mac_cache]
+    mov cx, 6
+    rep movsb
+    pop si
+    
+    ; Source MAC
+    push si
+    lea si, [ne2k_mac]
+    mov cx, 6
+    rep movsb
+    pop si
+    
+    ; Type: IP (0x0800) -> 0x0008 Big Endian
+    mov ax, 0x0008
+    stosw
+    
+    ; --- IP Body ---
+    mov di, disk_buffer + 14
+    
+    mov byte [di + IP_VHL], 0x45
+    mov byte [di + IP_TOS], 0x00
+    
+    ; Total Length (20 + Payload BX)
+    mov ax, bx
+    add ax, 20
+    xchg al, ah
+    mov [di + IP_LEN], ax
+    
+    ; ID
+    mov ax, [ip_id_counter]
+    inc ax
+    mov [ip_id_counter], ax
+    xchg al, ah
+    mov [di + IP_ID], ax
+    
+    ; Flags/Frag
+    mov word [di + IP_FRAG], 0x0000
+    
+    ; TTL
+    mov byte [di + IP_TTL], 64
+    
+    ; Protocol
+    mov [di + IP_PROTO], dl
+    
+    ; Checksum
+    mov word [di + IP_CKSUM], 0x0000
+    
+    ; Source IP
+    push si
+    lea si, [net_local_ip]
+    lea dx, [di + IP_SRC]
+    push di
+    mov di, dx
+    mov cx, 4
+    rep movsb
+    pop di
+    pop si
+    
+    ; Dest IP
+    push si
+    lea si, [arp_target_ip_cache]
+    lea dx, [di + IP_DST]
+    push di
+    mov di, dx
+    mov cx, 4
+    rep movsb
+    pop di
+    pop si
+    
+    ; Calculate IP Checksum
+    push si
+    lea si, [di]
+    mov cx, 20
+    call ip_calc_checksum
+    mov [di + IP_CKSUM], ax
+    pop si
+    
+    ; Copy Payload
+    push di
+    lea di, [di + 20]
+    mov cx, bx
+    rep movsb
+    pop di
+    
+    ; Total Packet Length = 14 + 20 + BX
+    mov cx, bx
+    add cx, 34
+    
+    ; Pad to 60 if needed
+    cmp cx, 60
+    jae .no_pad
+    mov cx, 60
+.no_pad:
+    
+    mov si, disk_buffer
+    call ne2000_send
+    
+    popa
+    ret
+
+; ------------------------------------------------------------------------------
+; ip_calc_checksum
+; IN:  DS:SI = Data, CX = Length in bytes
+; OUT: AX = Checksum (Big Endian)
+; ------------------------------------------------------------------------------
+ip_calc_checksum:
+    push bx
+    push cx
+    push dx
+    push si
+    
+    mov dx, cx          ; Save original length
+    xor ax, ax          ; Clear sum
+    xor bx, bx
+    
+    shr cx, 1           ; Loop for words
+    jz .odd_byte
+    
+.loop:
+    mov bx, [si]
+    add ax, bx
+    adc ax, 0           ; Add carry back for one's complement sum
+    add si, 2
+    loop .loop
+
+.odd_byte:
+    test dx, 1
+    jz .finish
+    mov bl, [si]        ; Last byte
+    xor bh, bh
+    add ax, bx
+    adc ax, 0
+
+.finish:
+    not ax              ; One's complement
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    ret

--- a/src/kernel/init.asm
+++ b/src/kernel/init.asm
@@ -14,6 +14,7 @@ init_system:
     call init_configs
     call init_display
     call init_security
+    call init_network
     call init_autoexec
     ret
 
@@ -97,6 +98,22 @@ init_security:
     mov si, security_init_msg
     call log_okay
 
+    ret
+
+init_network:
+    mov si, network_init_msg
+    call log_okay
+
+    call ne2000_probe
+    jnc .network_ok
+
+    mov si, network_fail_msg
+    call log_warn
+    ret
+
+.network_ok:
+    mov si, network_ok_msg
+    call log_okay
     ret
 
 init_autoexec:
@@ -953,6 +970,7 @@ display_init_msg         db 'Display initialization', 0
 mouse_init_msg           db 'Mouse driver loaded', 0
 security_init_msg        db 'Security check', 0
 shell_init_msg           db 'Shell initialization', 0
+network_init_msg         db 'NIC (Ne2000) initialization', 0
 
 ; Boot process messages
 first_boot_detected_msg  db 'First boot detected', 0
@@ -973,6 +991,8 @@ user_cfg_missed          db 'USER.CFG not found', 0
 pass_cfg_missed          db 'PASSWORD.CFG not found', 0
 prompt_cfg_missed        db 'PROMPT.CFG not found', 0
 logo_missed              db 'LOGO.BMP not found', 0
+network_ok_msg           db 'Net OK', 0
+network_fail_msg         db 'Net FAIL', 0
 user_cfg_size            dw 0
 prompt_cfg_size          dw 0
 password_cfg_size        dw 0

--- a/src/kernel/kernel.asm
+++ b/src/kernel/kernel.asm
@@ -579,6 +579,22 @@ get_cmd:
     call string_string_compare
     jc near cd_command
 
+    mov di, ping_string
+    call string_string_compare
+    jc near do_ping
+
+    mov di, setip_string
+    call string_string_compare
+    jc near do_setip
+
+    mov di, ip_string
+    call string_string_compare
+    jc near do_ip
+
+    mov di, netinfo_string
+    call string_string_compare
+    jc near do_netinfo
+
     mov si, command
     mov di, kernel_file
     call string_string_compare
@@ -2208,6 +2224,197 @@ cd_command:
 .already_root_msg   db 'Already in root directory', 0
 .failure_msg        db 'Directory not found or invalid', 0
 
+do_ping:
+    call print_newline
+    pusha
+
+    mov word si, [param_list]
+    call string_string_parse
+
+    test ax, ax
+    je .no_args
+
+    mov si, ax
+    call icmp_ping
+
+    popa
+    call print_newline
+    jmp get_cmd
+
+.no_args:
+    mov si, .no_args_msg
+    call print_string_red
+    call print_newline
+    popa
+    call print_newline
+    jmp get_cmd
+
+.no_args_msg db 'Usage: PING <IPv4 address>', 0
+
+do_ip:
+    call print_newline
+    pusha
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+
+    mov si, do_ip_debug_msg
+    call print_string
+    call print_newline
+
+    mov si, ip_status_msg
+    call print_string
+    
+    mov al, [net_local_ip]
+    xor ah, ah
+    call .print_ip_part
+    
+    mov al, '.'
+    call print_char
+    
+    mov al, [net_local_ip+1]
+    xor ah, ah
+    call .print_ip_part
+    
+    mov al, '.'
+    call print_char
+    
+    mov al, [net_local_ip+2]
+    xor ah, ah
+    call .print_ip_part
+    
+    mov al, '.'
+    call print_char
+    
+    mov al, [net_local_ip+3]
+    xor ah, ah
+    call .print_ip_part
+    
+    popa
+    call print_newline
+    jmp get_cmd
+
+.print_ip_part:
+    call string_int_to_string
+    mov si, ax
+    call print_string
+    ret
+
+do_setip:
+    call print_newline
+    pusha
+
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    
+    mov word si, [param_list]
+    call string_string_parse
+    test ax, ax
+    je .no_args
+    
+    mov si, ax
+    lea di, [net_local_ip]
+    call icmp_parse_ip
+    jc .error_parse
+    
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    
+    mov si, ip_set_success
+    call print_string_green
+    call print_newline
+
+    mov si, ip_set_debug_msg
+    call print_string
+    mov al, [net_local_ip]
+    xor ah, ah
+    call print_decimal
+    mov al, '.'
+    call print_char
+    mov al, [net_local_ip+1]
+    xor ah, ah
+    call print_decimal
+    mov al, '.'
+    call print_char
+    mov al, [net_local_ip+2]
+    xor ah, ah
+    call print_decimal
+    mov al, '.'
+    call print_char
+    mov al, [net_local_ip+3]
+    xor ah, ah
+    call print_decimal
+
+    popa
+    call print_newline
+    jmp get_cmd
+
+.no_args:
+    mov si, ip_usage_msg
+    call print_string_red
+    jmp .exit
+.error_parse:
+    mov si, ip_invalid_msg
+    call print_string_red
+.exit:
+    popa
+    call print_newline
+    jmp get_cmd
+
+do_netinfo:
+    call print_newline
+    pusha
+    
+    ; Show I/O Port
+    mov si, ni_io_msg
+    call print_string
+    mov ax, [ne2k_iobase]
+    mov al, ah
+    call print_hex_byte
+    mov ax, [ne2k_iobase]
+    call print_hex_byte
+    call print_newline
+    
+    ; Show MAC Address
+    mov si, ni_mac_msg
+    call print_string
+    lea si, [ne2k_mac]
+    mov cx, 5
+.mac_loop:
+    mov al, [si]
+    call print_hex_byte
+    mov al, ':'
+    call print_char
+    inc si
+    loop .mac_loop
+    mov al, [si]
+    call print_hex_byte
+    
+    call print_newline
+    popa
+    jmp get_cmd
+
+; IN: AL = byte to print in hex
+print_hex_byte:
+    push ax
+    shr al, 4
+    call .nibble_to_hex
+    call print_char
+    pop ax
+    and al, 0x0F
+    call .nibble_to_hex
+    call print_char
+    ret
+.nibble_to_hex:
+    add al, '0'
+    cmp al, '9'
+    jbe .hex_done
+    add al, 7
+.hex_done:
+    ret
+
 %INCLUDE "src/kernel/init.asm"                      ; x16-PRos initialisation
 %INCLUDE "src/kernel/log.asm"                       ; Log functions
 %INCLUDE "src/kernel/features/fs.asm"               ; FAT12 filesystem functions
@@ -2222,7 +2429,14 @@ cd_command:
 
 ; ====== DRIVERS ======
 %INCLUDE "src/drivers/ps2_mouse.asm"                ; Mouse driver
+%INCLUDE "src/drivers/net/ne2000/ne2000.asm"        ; NE2000 driver
 ; =====================
+
+; ====== NETWORK STACK ======
+%INCLUDE "src/kernel/InternetProtocol/arp.asm"
+%INCLUDE "src/kernel/InternetProtocol/ip.asm"
+%INCLUDE "src/kernel/InternetProtocol/icmp.asm"
+; ===========================
 
 ; ====== API ======
 %INCLUDE "src/kernel/features/api/api_output.asm"
@@ -2231,47 +2445,23 @@ cd_command:
 
 ; ===================== Data Section =====================
 section .data
+net_local_ip      db 10, 0, 2, 15
 ; ------ Header ------
 header db 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB2, 0xB2, 0xB2, 0xB2, 0xB2, 0xB2, 0xDB, 0xDB, ' ', 'x16 PRos v0.8', ' ', 0xDB, 0xDB, 0xB2, 0xB2, 0xB2, 0xB2, 0xB2, 0xB2, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB1, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0xB0, 0
 
 ; ------ Help ------
-kshell_comands db 'HELP               - get list of commands', 10, 13
-               db 'INFO               - system information', 10, 13
-               db 'VER                - terminal version', 10, 13
-               db 'CLS                - clear screen', 10, 13
-               db 'SHUT               - shutdown', 10, 13
-               db 'REBOOT             - restart', 10, 13
-               db 'DATE               - current date (DD/MM/YY)', 10, 13
-               db 'TIME               - current time (HH:MM:SS)', 10, 13
-               db 'CPU                - CPU info', 10, 13
-               db 'DIR                - list files', 10, 13
-               db 'SIZE   <f>         - file size', 10, 13
-               db 'CAT    <f>         - show file', 10, 13
-               db 'DEL    <f>         - delete file', 10, 13
-               db 'COPY   <f1> <f2>   - copy file (root only)', 10, 13
-               db 'REN    <f1> <f2>   - rename file (root only)', 10, 13
-               db 'TOUCH  <f>         - create empty file', 10, 13
-               db 'WRITE  <f> <text>  - write to file', 10, 13
-               db 'VIEW   <f> <flags> - view BMP image', 10, 13
-               db 'CD     <dir>       - change directory', 10, 13
-               db 'MKDIR  <dir>       - create directory', 10, 13
-               db 'DELDIR <dir>       - delete directory', 10, 13
-               db 'EXIT               - exit to bootloader', 10, 13, 0
+kshell_comands db 'HELP,INFO,VER,CLS,SHUT,REBOOT,DATE,TIME,CPU,DIR,CD,MKDIR,DELDIR', 10, 13
+               db 'SIZE,CAT,DEL,COPY,REN,TOUCH,WRITE,VIEW<f>,PING<ip>,SETIP<ip>,IP,NET,EXIT', 10, 13, 0
 
 ; ------ About OS ------
 info db 10, 13
      db 20 dup(0xC4), ' INFO ', 21 dup(0xC4), 10, 13
-     db '  x16 PRos is the simple 16 bit operating', 10, 13
-     db '  system written in NASM for x86 PC`s ', 10, 13
-     db 47 dup(0xC4), 10, 13
-     db '  Author:           PRoX   (https://github.com/PRoX2011)', 10, 13
-     db '  Support project:  DALink (https://dalink.to/PRoXdev)', 10, 13
-     db '  Source code:      GitHub (https://github.com/PRoX2011/x16-PRos)', 10, 13
-     db '  License:          MIT', 10, 13
-     db '  OS version:       0.8', 10, 13
+     db '  x16 PRos - Simple 16-bit NASM OS', 10, 13
+     db '  Author  : PRoX (proxdev.com)', 10, 13
+     db '  Version : 0.8 / License: MIT', 10, 13
      db 0
 
-version_msg db 'PRos Terminal v0.3', 10, 13, 0
+version_msg db 'v0.3', 10, 13, 0
 
 ; ------ Commands ------
 exit_string    db 'EXIT', 0
@@ -2296,6 +2486,10 @@ view_string    db 'VIEW', 0
 mkdir_string   db 'MKDIR', 0
 deldir_string  db 'DELDIR', 0
 cd_string      db 'CD', 0
+ping_string    db 'PING', 0
+setip_string   db 'SETIP', 0
+ip_string      db 'IP', 0
+netinfo_string db 'NETINFO', 0
 
 autocomplete_cmd_table:
     dw exit_string, help_string, info_string, cls_string
@@ -2303,7 +2497,7 @@ autocomplete_cmd_table:
     dw cat_string, del_string, copy_string, ren_string
     dw size_string, shut_string, reboot_string, cpu_string
     dw touch_string, write_string, view_string, mkdir_string
-    dw deldir_string
+    dw deldir_string, ping_string, setip_string, ip_string, netinfo_string
     dw 0
 
 ; ------ Errors ------
@@ -2317,6 +2511,14 @@ kern_warn2_msg    db 'Cannot delete kernel file!', 0
 notext_msg        db 'No text provided for writing', 0
 APM_error_msg     db "APM error or APM not available",0
 bad_drive_msg     db 'Drive not ready or does not exist!', 0
+ip_status_msg     db 'Current local IP: ', 0
+ip_usage_msg      db 'Usage: SETIP <ip>', 0
+ip_invalid_msg    db 'Bad IP', 0
+ip_set_success    db 'IP set', 0
+ip_set_debug_msg  db 'DBG net_local_ip: ', 0
+do_ip_debug_msg   db 'DBG do_ip entry', 0
+ni_io_msg         db 'IO:', 0
+ni_mac_msg        db 'MA:', 0
 
 ; ------ CPU info ------
 flags_str          db '  FLAGS: ', 0
@@ -2414,10 +2616,7 @@ conf_dir_name        db 'CONF.DIR', 0
 
 current_drive_char   db 'A'
 
-login_password_prompt  db 19 dup(' '), 0xC9, 39 dup(0xCD), 0xBB, 10, 13
-                       db 19 dup(' '), 0xBA, '        Enter your password:           ', 0xBA, 10, 13
-                       db 19 dup(' '), 0xBA, '    _______________________________    ', 0xBA, 10, 13
-                       db 19 dup(' '), 0xC0, 39 dup(0xCD), 0xBC, 10, 13, 0
+login_password_prompt  db 10, 13, ' [ Password: ] ', 0
 
 mt                   db '', 10, 13, 0
 Sides                dw 2

--- a/todo.txt
+++ b/todo.txt
@@ -2,7 +2,7 @@
 [     TODO    ] Implement cooperative multitasking
 [     TODO    ] Add malloc, mfree
 [     TODO    ] Add the ability to compile x16-PRos to ISO image
-[     TODO    ] Add internet driver
+[     DONE    ] Add internet driver
 [     TODO    ] Separate PRos Terminal from kernel
 [     TODO    ] I/O redirection and pipes (cmd > file, cmd1 | cmd2)
 [     TODO    ] Batch script support (.BAT / .SH style)


### PR DESCRIPTION
2. updated help.asm about networking commands. on the fork i did it with a separate git push because i forgot earlier
new commands:
netinfo
ip
setip <IPv4>
ping <IPv4>
i only tested it within inside special network prepared by QEMU (not on the linux kernel's loopback)
available IPs:
Gateway (host to guest): 10.0.2.2
guest itself (gets it without setip): 10.0.2.15