### PR TITLE
Update bootloader to support larger kernel size

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -15,8 +15,9 @@ FLAG_NO_LOGO_DISPLAY=0
 FLAG_NO_SETUP=0
 FLAG_DTM=0  # DTM - Dev Tesing Mode
 
-MAX_KERNEL_LOADER_BYTES=32768
-KERNEL_SIZE_WARN_BYTES=30720
+# Max8086Memory - KernelAddress - FatBootCHSBuffer
+MAX_KERNEL_LOADER_BYTES=$((655360-0x20000-65536))
+KERNEL_SIZE_WARN_BYTES= $(($MAX_KERNEL_LOADER_BYTES - 2048))
 
 for arg in $@; do
     if [ $arg == "-quiet" ]; then FLAG_QUIET_MODE=1; continue; fi
@@ -113,7 +114,12 @@ echo -e "$NC"
 # Compile bootloader
 if [ $FLAG_NO_BOOT_RECOMP == 0 ]; then
     print_info "Compiling bootloader (boot.asm => bin/BOOT.BIN)..."
-    nasm -f bin src/bootloader/boot.asm -o bin/BOOT.BIN
+    nasm -f bin src/bootloader/boot.asm -o bin/BOOT.BIN \
+        -DFILENAME="\"KERNEL  BIN\"" \
+        -DLOAD_SEGMENT="0x2000" \
+        -DLOAD_OFFSET="0x0000" \
+        -DJMP_SEGMENT="0x2000" \
+        -DJMP_OFFSET="0x0000"
     check_error "Bootloader compilation failed"
     print_ok "Bootloader compiled successfully"
 fi
@@ -150,13 +156,13 @@ check_error "Disk image creation failed"
 print_ok "Disk image created successfully"
 
 print_info "Formatting disk image..."
-mkfs.vfat disk_img/x16pros.img -n "x16-PROS"
+mkfs.vfat -F 12 disk_img/x16pros.img -n "x16-PROS"
 check_error "Disk formatting failed"
 print_ok "Disk image formatted successfully"
 
 # Write bootloader
 print_info "Writing bootloader to disk..."
-dd status=none if=bin/BOOT.BIN of=disk_img/x16pros.img conv=notrunc
+dd status=none if=bin/BOOT.BIN of=disk_img/x16pros.img bs=1 seek=62 conv=notrunc # Write boot code after BPB
 check_error "Bootloader writing failed"
 print_ok "Bootloader written successfully"
 

--- a/docs/Bootloader.md
+++ b/docs/Bootloader.md
@@ -1,22 +1,24 @@
-# x16-PRos Bootloader Documentation
+# FatBoot Bootloader Documentation
 
 ## Overview
 
-The x16-PRos bootloader is a 16-bit real-mode program that loads the operating system kernel (`KERNEL.BIN`) from a
-FAT12-formatted 1.44 MB floppy disk into memory at address `0x2000:0x0000` and transfers control to it. It resides in
-the boot sector of the floppy disk (first 512 bytes) and is executed by the BIOS upon system startup. The bootloader
-uses BIOS interrupts to read disk sectors and navigate the FAT12 file system to locate and load the kernel.
+The x16-PRos operating system uses the FatBoot bootloader (https://github.com/invin1x/FatBoot).
+
+FatBoot is a 16-bit real-mode program that loads the operating system kernel file from a FAT12-formatted
+drive into memory and transfers control to it. It resides in the boot sector (first 512 bytes of the drive)
+and is executed by the BIOS upon system startup. The bootloader uses BIOS interrupts to read disk sectors
+and navigate the FAT12 file system to locate and load the kernel.
 
 ## Purpose
 
 The primary functions of the bootloader are:
 
 1. Initialize the system environment (segment registers and stack).
-2. Read the FAT12 root directory to locate the `KERNEL.BIN` file.
-3. Load the File Allocation Table (FAT) to determine the kernel's disk clusters.
-4. Read the kernel's data clusters into memory.
+2. Read the disk and filesystem configuration.
+3. Read the FAT12 root directory to locate the kernel.
+4. Read the kernel's data clusters into memory, using File Allocation Table (FAT).
 5. Transfer control to the loaded kernel.
-6. Handle errors, such as a missing kernel file, by displaying a message and rebooting.
+6. Handle errors, such as a missing kernel file or a bad cluster, by displaying a message and rebooting.
 
 ## Operational Principles
 
@@ -24,157 +26,74 @@ The bootloader operates in the following stages:
 
 ### 1. Initialization
 
-- **Segment Setup**: The bootloader sets the data segment (`DS`), extra segment (`ES`), file segment (`FS`), and general
-  segment (`GS`) to `0x07C0`, the segment where the boot sector is loaded by the BIOS. The stack segment (`SS`) is set
-  to `0x0000`, with the stack pointer (`SP`) initialized to `0xFFFF` for a descending stack.
-- **Interrupts**: Interrupts are disabled (`cli`) during segment setup and re-enabled (`sti`) afterward to allow BIOS
-  interrupt calls.
-- **Output**: Displays a "Loading Boot Image" message using BIOS interrupt `0x10` (function `0x0E`) to indicate the
-  start of the boot process.
+- **Segment Setup**: The bootloader sets the data segment (`DS`), extra segment (`ES`), and stack segment (`SS`)
+  to `0x0000`, and stack pointer (`SP`) to `0x500 + 64`.
+- **Boot Sector Relocation**: The bootloader copies itself to `0x500 + 64`, right above IVT, BDA, and stack, and then jumps there.
 
 ### 2. Reading the Root Directory
 
-- **Calculation**: Computes the starting sector of the root directory using the FAT12 Boot Parameter Block (BPB):
-    - Root directory size = `bpbRootEntries` (224) * 32 bytes per entry / `bpbBytesPerSector` (512) = number of sectors.
-    - Start sector = `bpbReservedSectors` (1) + (`bpbNumberOfFATs` (2) * `bpbSectorsPerFAT` (9)).
-    - Stores the data sector start (after root directory) in `datasector`.
-- **Disk Read**: Reads the root directory sectors into memory at `0x07C0:0x0200` using the `ReadSectors` function, which
-  calls BIOS interrupt `0x13` (function `0x02`).
-- **Error Handling**: Retries up to 5 times on disk read failure, resetting the floppy drive (`int 0x13`, `AH = 0x00`)
-  between attempts. If all retries fail, jumps to `FAILURE`.
+- **Calculation**: After initialization, the bootloader calculates and saves FAT LBA, root directory LBA, and data area LBA,
+  using the following formulas:
+    - FAT_LBA = `BPB_reserved_sectors` + `BPB_partition_LBA`.
+    - Root_directory_LBA = FAT_LBA + `BPB_sectors_per_FAT` * `BPB_num_fats`.
+    - Data_area_LBA = Root_directory_LBA + `BPB_root_entries` * 32 / `BPB_bytes_per_sector`.
+- **Disk Read**: Then the bootloader reads the root directory sectors into memory at `0x0000:0x1000` using the `read_disk` procedure, which
+  calls BIOS interrupt `0x13` (function `0x42` or `0x02` as fallback).
 
 ### 3. Locating the Kernel
 
-- **Search**: Scans the root directory (224 entries) at `0x07C0:0x0200` for the file `KERNEL.BIN` by comparing each
-  entry’s 11-byte filename field with the string `"KERNEL  BIN"`.
-- **Match**: If found, retrieves the file’s starting cluster from the directory entry (offset 0x1A) and stores it in
-  `cluster`.
-- **Failure**: If no match is found, displays an error message ("KERNEL.BIN not found") and waits for a keypress before
-  rebooting via `int 0x19`.
+- **Search**: Scans the root directory (`BPB_root_entries` entries) at `0x0000:0x1000` for the kernel by comparing each
+  entry’s 11-byte filename field with the string defined at assembly time (see below).
+- **Match**: If found, checks flags (offset 0xB), retrieves the file’s starting cluster from the directory entry (offset 0x1A) and
+  starts reading it.
 
-### 4. Loading the FAT
-
-- **Calculation**: Reads the FAT (9 sectors per copy, 2 copies) starting at `bpbReservedSectors` (1) into
-  `0x07C0:0x0200`.
-- **Disk Read**: Uses `ReadSectors` to load the FAT, with retries and error handling as in the root directory read.
-- **Purpose**: The FAT is used to determine the chain of clusters containing the kernel’s data.
-
-### 5. Loading the Kernel
+### 4. Loading the Kernel
 
 - **Cluster Chain**: Iteratively loads the kernel’s clusters:
-    - Converts the current cluster number (from `cluster`) to a Logical Block Address (LBA) using `ClusterLBA`, which
-      accounts for the data area’s offset (`datasector`).
-    - Converts the LBA to Cylinder-Head-Sector (CHS) format using `LBACHS` for BIOS disk reads.
-    - Reads one sector at a time into `0x2000:0x0000` (incrementing the offset by 512 bytes per sector) using
-      `ReadSectors`.
-    - Retrieves the next cluster from the FAT:
-        - For even-numbered clusters: Takes the low 12 bits of the FAT entry.
-        - For odd-numbered clusters: Takes the high 12 bits (shifted right by 4).
-    - Continues until a cluster value ≥ `0x0FF0` (end-of-file marker) is encountered.
-- **Output**: Displays a progress dot (`.`) for each sector read.
+    - Calculates the required FAT sector, and loads it to `FAT_BUFFER` using `read_disk` procedure.
+    - Gets the next cluster number and checks if it is correct.
+    - Reads one cluster at a time into `LOAD_ADDRESS + READ_SECTORS` (incrementing the `READ_SECTORS` by `BPB_sectors_per_cluster`) using
+      `read_disk` procedure.
 
-### 6. Transferring Control
+### 5. Transferring Control
 
-- **Jump**: After loading all clusters, displays a newline (`msgCRLF`) and transfers control to the kernel at
-  `0x2000:0x0000` using a far return (`retf`) with the stack set up to point to this address.
-- **Environment**: The kernel is executed in a 16-bit real-mode environment with `DS`, `ES`, `FS`, and `GS` expected to
+- **Jump**: After loading all clusters, transfers control to the kernel using a far jump.
+- **Environment**: The kernel is executed in a 16-bit real-mode environment with all registers expected to
   be set by the kernel itself.
 
-### 7. Error Handling
+### 6. Error Handling
 
-- **Disk Errors**: The `ReadSectors` function retries disk reads up to 5 times, resetting the floppy drive on failure.
-  Persistent failures trigger a reboot via `int 0x18`.
-- **File Not Found**: If `KERNEL.BIN` is not found, the bootloader displays an error message and reboots after a
-  keypress.
-- **Progress Feedback**: Progress dots and messages are displayed to inform the user of the loading process.
+- If any error occurs, the bootloader displays an error message and reboots after a keypress.
 
 ## Key Functions
 
-### `Print`
+### `read_disk`
 
-- **Purpose**: Outputs a null-terminated string to the screen using BIOS interrupt `0x10` (function `0x0E`).
-- **Input**: `SI` = Pointer to string.
-- **Output**: Characters displayed on the screen.
-
-### `ClusterLBA`
-
-- **Purpose**: Converts a FAT12 cluster number to an LBA.
-- **Input**: `AX` = Cluster number.
-- **Output**: `AX` = LBA of the cluster’s first sector.
-- **Formula**: LBA = (cluster - 2) * `bpbSectorsPerCluster` + `datasector`.
-
-### `LBACHS`
-
-- **Purpose**: Converts an LBA to CHS format for BIOS disk reads.
-- **Input**: `AX` = LBA.
-- **Output**:
-    - `absoluteSector` = Sector number (1-based).
-    - `absoluteHead` = Head number.
-    - `absoluteTrack` = Cylinder number.
-- **Formula**:
-    - Sector = (LBA % `bpbSectorsPerTrack`) + 1.
-    - Cylinder = (LBA / `bpbSectorsPerTrack`) / `bpbHeadsPerCylinder`.
-    - Head = (LBA / `bpbSectorsPerTrack`) % `bpbHeadsPerCylinder`.
-
-### `ReadSectors`
-
-- **Purpose**: Reads one or more sectors from the disk into memory.
+- **Purpose**: Reads the specified number of sectors from the disk to the specified buffer,
+  using BIOS interrupt `0x13`, function `0x42`. If an error has occurred, it tries to convert the
+  given LBA address to CHS, and read sectors again using legacy function `0x02`.
 - **Input**:
-    - `AX` = Starting LBA.
-    - `BX` = Memory offset to load data (in `ES`).
-    - `CX` = Number of sectors to read.
-- **Output**: Data loaded into `ES:BX`, with `BX` incremented by 512 bytes per sector.
-- **Error Handling**: Retries up to 5 times on failure, resetting the drive. Triggers `int 0x18` on persistent failure.
+    - `DX:AX` = LBA.
+    - `CX` = Sectors to read.
+    - `ES:BX` = Buffer address.
+    - `[DISK]` = Disk number.
+- **Output**: `AX`, `BX`, `CX`, `DX`, `SI` and `DI` are not saved, and `DS` is set to 0.
 
-## BPB (Boot Parameter Block)
+### `error`
 
-The BPB defines the FAT12 file system parameters:
+- **Purpose**: Displays the error message and waits for a keypress to reboot.
 
-- **OEM Identifier**: `"x16-PRos"`
-- **Bytes per Sector**: 512
-- **Sectors per Cluster**: 1
-- **Reserved Sectors**: 1 (boot sector)
-- **Number of FATs**: 2
-- **Root Entries**: 224
-- **Total Sectors**: 2880 (1.44 MB floppy)
-- **Media Descriptor**: `0xF0` (removable)
-- **Sectors per FAT**: 9
-- **Sectors per Track**: 18
-- **Heads per Cylinder**: 2
-- **Drive Number**: 0 (auto-detected)
-- **Extended Boot Signature**: `0x29`
-- **Serial Number**: `0xa0a1a2a3`
-- **Volume Label**: `"FLOPPY "`
-- **File System Type**: `"FAT12   "`
+## Configuration
 
-## Memory Layout
-
-- **Boot Sector**: Loaded at `0x07C0:0x0000` (physical address `0x7C00`).
-- **Root Directory and FAT**: Loaded at `0x07C0:0x0200`.
-- **Kernel**: Loaded at `0x2000:0x0000`.
-- **Stack**: Grows downward from `0x0000:0xFFFF`.
-
-## Limitations
-
-- **File Name**: Hardcoded to `KERNEL.BIN` (11-byte FAT12 format).
-- **Disk Size**: Assumes a 1.44 MB floppy disk (2880 sectors).
-- **Error Handling**: Limited to retrying disk reads and rebooting on failure.
-- **Memory**: Kernel must fit within the memory starting at `0x2000:0x0000` and handle its own segment setup.
-
-## Example Flow
-
-1. BIOS loads the boot sector at `0x7C00`.
-2. Bootloader initializes segments and stack, displays "Loading Boot Image".
-3. Reads the root directory (sectors 19–32) into `0x07C0:0x0200`.
-4. Searches for `KERNEL.BIN` and retrieves its starting cluster.
-5. Reads the FAT (sectors 1–18) into `0x07C0:0x0200`.
-6. Loads the kernel’s clusters into `0x2000:0x0000`, following the FAT chain.
-7. Jumps to `0x2000:0x0000` to execute the kernel.
-8. On failure, displays an error and reboots.
+- To configure FatBoot, define these macros during assembling:
+    - `FILENAME` - The name of the file to load (8.3 format).
+    - `LOAD_SEGMENT` - The segment where the file will be loaded.
+    - `LOAD_OFFSET` - The offset at which the file will be loaded.
+    - `JMP_SEGMENT` - The segment to jump to after loading.
+    - `JMP_OFFSET` - The offset to jump to after loading.
 
 ## License
 
-The x16-PRos bootloader is licensed under the MIT License. See the LICENSE.TXT for details.
+The FatBoot bootloader is licensed under the MIT License.
 
-**Author**: PRoX (https://github.com/PRoX2011)
-**Version**: 0.4
+**Author**: Alexander Zubov <alextop1bb@gmail.com> (https://github.com/invin1x)

--- a/src/bootloader/boot.asm
+++ b/src/bootloader/boot.asm
@@ -1,252 +1,287 @@
-; ==================================================================
-; x16-PRos -- The x16-PRos bootloader
-; Copyright (C) 2025 PRoX2011
-;
-; Loads the kernel (KERNEL.BIN) for execution.
-; Uses FAT12 file system.
-; ==================================================================
+; This file is a part of FatBoot project (https://github.com/invin1x/FatBoot)
+; Copyright (c) 2025 Alexander Zubov
+; Licensed under the MIT License
 
-[BITS 16]
-[ORG 0x0000]
-[CPU 8086]
+; Define these macros before assembly:
+;   Macros        Description                                   Example
+;   ---------------------------------------------------------------------------
+;   FILENAME      The name of the file to load (8.3 format).    "KERNEL  BIN"
+;   LOAD_SEGMENT  The segment where the file will be loaded.    0x0100
+;   LOAD_OFFSET   The offset at which the file will be loaded.  0x0000
+;   JMP_SEGMENT   The segment to jump to after loading.         0x0100
+;   JMP_OFFSET    The offset to jump to after loading.          0x0100
 
-start: jmp main
+; Note: 0xB4B is THE LOWEST physical address at whitch the file can be loaded.
+; If CHS addressing is used while reading a disk, 0x90000-0x9FFFF
+; will be used as a temporary buffer due to ISA DMA limitations.
 
-; ========================= DISK PARAMETERS ========================
+; -----------------------------------------------------------------------------
 
-; bpbOEM               - 8-byte OEM identifier
-; bpbBytesPerSector    - Bytes per sector (512)
-; bpbSectorsPerCluster - Sectors per allocation unit (1)
-; bpbReservedSectors   - Reserved sectors including boot sector (1)
-; bpbNumberOfFATs      - Number of FAT copies (2)
-; bpbRootEntries       - Max root directory entries (224)
-; bpbTotalSectors      - Total sectors on disk (2880)
-; bpbMedia             - Media descriptor (0xF0 = removable)
-; bpbSectorsPerFAT     - Sectors per FAT table (9)
-; bpbSectorsPerTrack   - Sectors per track (18)
-; bpbHeadsPerCylinder  - Number of heads (2)
-; bpbHiddenSectors     - Hidden sectors (0)
-; bpbTotalSectorsBig   - Large sector count (0)
-; bsDriveNumber        - Drive number (0 = auto)
-; bsUnused             - Reserved (0)
-; bsExtBootSignature   - Extended boot sig (0x29)
-; bsSerialNumber       - Volume serial number
-; bsVolumeLabel        - 11-byte volume label
-; bsFileSystem         - 8-byte filesystem type
+; IVT (1024 bytes) + BDA (256 bytes) + stack (64 bytes) = 0x500 + 64
+RELOC_ADDR EQU 0x500 + 64
 
-bpbOEM               DB "x16-PROS"
-bpbBytesPerSector    DW 512
-bpbSectorsPerCluster DB 1
-bpbReservedSectors   DW 1
-bpbNumberOfFATs      DB 2
-bpbRootEntries       DW 224
-bpbTotalSectors      DW 2880
-bpbMedia             DB 0xf0
-bpbSectorsPerFAT     DW 9
-bpbSectorsPerTrack   DW 18
-bpbHeadsPerCylinder  DW 2
-bpbHiddenSectors     DD 0
-bpbTotalSectorsBig   DD 0
-bsDriveNumber        DB 0
-bsUnused             DB 0
-bsExtBootSignature   DB 0x29
-bsSerialNumber       DD 0x00000000
-bsVolumeLabel        DB "x16-PROS   "
-bsFileSystem         DB "FAT12   "
+; CHS reading buffer is right before the upper memory area
+CHS_BUFFER_SEGMENT EQU 0x9000
+CHS_BUFFER_OFFSET  EQU 0x0000
 
-; ===================================================================
+; Bios Parameter Block
+BPB_OEM_id              EQU RELOC_ADDR + 0x03  ; 8 BYTES
+BPB_bytes_per_sector    EQU RELOC_ADDR + 0x0B  ; WORD
+BPB_sectors_per_cluster EQU RELOC_ADDR + 0x0D  ; BYTE
+BPB_reserved_sectors    EQU RELOC_ADDR + 0x0E  ; WORD
+BPB_num_fats            EQU RELOC_ADDR + 0x10  ; BYTE
+BPB_root_entries        EQU RELOC_ADDR + 0x11  ; WORD
+BPB_total_sectors_16    EQU RELOC_ADDR + 0x13  ; WORD
+BPB_media               EQU RELOC_ADDR + 0x15  ; BYTE
+BPB_sectors_per_FAT     EQU RELOC_ADDR + 0x16  ; WORD
+BPB_sectors_per_track   EQU RELOC_ADDR + 0x18  ; WORD
+BPB_heads               EQU RELOC_ADDR + 0x1A  ; WORD
+BPB_partition_LBA       EQU RELOC_ADDR + 0x1C  ; DWORD
+BPB_total_sectors_32    EQU RELOC_ADDR + 0x20  ; DWORD
 
+; Where to store temp data
+FAT_LBA      EQU RELOC_ADDR + 512       ; DWORD
+DATA_LBA     EQU RELOC_ADDR + 512 + 4   ; DWORD
+DISK         EQU RELOC_ADDR + 512 + 8   ; BYTE
+READ_SECTORS EQU RELOC_ADDR + 512 + 9   ; WORD
+FAT_BUFFER   EQU RELOC_ADDR + 512 + 11  ; 2 sectors (usually 1024 bytes)
 
-Print:
-    lodsb
-    or al, al
-    jz PrintDone
-    mov ah, 0eh
-    int 10h
-    jmp Print
-PrintDone:
-    ret
+; Physical address at which file will be loaded
+LOAD_PHYS EQU ((LOAD_SEGMENT << 4) + LOAD_OFFSET)
 
-absoluteSector db 0x00
-absoluteHead db 0x00
-absoluteTrack db 0x00
+BITS 16
+CPU 8086
+ORG RELOC_ADDR + 62  ; Right after BPB in relocated boot sector
 
-ClusterLBA:
-    sub ax, 0x0002
-    xor cx, cx
-    mov cl, BYTE [bpbSectorsPerCluster]
-    mul cx
-    add ax, WORD [datasector]
-    ret
+; Initialization
+xor ax, ax                  ; AX = 0
+mov ds, ax                  ; Data segment = 0
+mov es, ax                  ; Extra segment = 0
+mov ss, ax                  ; Stack segment = 0
+mov sp, RELOC_ADDR          ; Stack is under relocated boot sector
 
-LBACHS:
-    xor dx, dx
-    div WORD [bpbSectorsPerTrack]
-    inc dl
-    mov BYTE [absoluteSector], dl
-    xor dx, dx
-    div WORD [bpbHeadsPerCylinder]
-    mov BYTE [absoluteHead], dl
-    mov BYTE [absoluteTrack], al
-    ret
+; Copy boot sector
+mov si, 0x7C00              ; Source
+mov di, RELOC_ADDR          ; Destination
+mov cx, 512                 ; Bytes to copy
+rep movsb                   ; Copy
 
-ReadSectors:
-    .MAIN
-    mov di, 0x0005
-.SECTORLOOP
+; Far jump to relocated code
+jmp 0x0000:($+5)
+
+; Save boot disk number
+mov [DISK], dl
+
+; Calculate FAT LBA = reserved sectors + partition LBA
+xor bx, bx                          ; BX:CX = reserved sectors
+mov cx, [BPB_reserved_sectors]
+add cx, [BPB_partition_LBA]         ; BX:CX += partition LBA
+adc bx, [BPB_partition_LBA + 2]
+mov [FAT_LBA], cx                   ; Save BX:CX (FAT LBA)
+mov [FAT_LBA + 2], bx
+
+; Calculate root LBA = FATs * sectors per FAT + FAT LBA
+mov al, [BPB_num_fats]              ; AX = FATs (AH == 0)
+mul word [BPB_sectors_per_FAT]      ; DX:AX = AX * sectors per FAT
+add cx, ax                          ; BX:CX = FAT LBA + DX:AX = root LBA
+adc bx, dx
+push bx                             ; Save root LBA to stack
+push cx
+
+; Calculate data area LBA = root entries * 32 / bytes per sector + root LBA
+mov ax, 32                          ; AX = 32
+mul word [BPB_root_entries]         ; DX:AX = 32 * root entries
+div word [BPB_bytes_per_sector]     ; DX:AX /= bytes per sector = root sectors
+push ax                             ; Save root sectors to stack
+add cx, ax                          ; BX:CX = data area LBA
+adc bx, 0
+mov [DATA_LBA], cx                  ; Save data area LBA
+mov [DATA_LBA + 2], bx
+
+; Read root directory
+pop cx                              ; Restore root sectors from stack in CX
+pop ax                              ; Restore root LBA from stack in DX:AX
+pop dx
+mov bx, 0x1000                      ; Buffer address
+push bx                             ; Save it to stack
+call read_disk                      ; Read
+
+; Find file entry in root directory
+mov cx, [BPB_root_entries]          ; CX = root directory entries
+pop si                              ; Current entry = buffer address from stack
+.find:
+    mov di, filename                ; DI = pointer to filename
+    push cx                         ; Save CX to stack
+    mov cx, 11                      ; CX = 11 (filename length)
+    repe cmpsb                      ; Compare filenames
+    je .found                       ; Jump if match
+    add si, cx                      ; Point SI to next entry
+    add si, 32 - 11
+    pop cx                          ; Restore CX from stack
+    loop .find                      ; Check next entry
+    jmp error                       ; Error if checked all entries
+.found:
+    pop cx                          ; Free stack
+
+; Check flags
+and byte [si], 11011000b            ; Check if flags are correct
+jnz error                           ; Error if flags are not correct
+
+; Read file
+mov ax, [si - 11 + 26]              ; AX = current cluster number
+mov word [READ_SECTORS], 0          ; Current read sectors number = 0
+.read:
+    push ax                         ; Save current cluster number to stack
+    TIMES 2 dec ax                  ; AX -= 2 = cluster index
+    cmp ax, 0xFEF - 2               ; Check if cluster index is valid
+    ja error                        ; Error if not valid
+    xor ch, ch                      ; CX = cluster size (sectors to read)
+    mov cl, [BPB_sectors_per_cluster]
+    push cx                         ; Save cluster size to stack
+    mul cx                          ; DX:AX = AX * CX = sector in data area
+    add ax, [DATA_LBA]              ; DX:AX += data area LBA = cluster LBA
+    adc dx, [DATA_LBA + 2]
+    push dx                         ; Save cluster LBA to stack
     push ax
-    push bx
-    push cx
-    call LBACHS
-    mov ah, 0x02
-    mov al, 0x01
-    mov ch, BYTE [absoluteTrack]
-    mov cl, BYTE [absoluteSector]
-    mov dh, BYTE [absoluteHead]
-    mov dl, BYTE [bsDriveNumber]
-    int 0x13
-    jnc .SUCCESS
-    xor ax, ax
-    int 0x13
-    dec di
-    pop cx
-    pop bx
-    pop ax
-    jnz .SECTORLOOP
-    int 0x18
-.SUCCESS
-    mov si, msgProgress
-    call Print
-    pop cx
-    pop bx
-    pop ax
-    add bx, WORD [bpbBytesPerSector]
-    jnc .NEXT
-    mov dx, es
-    cmp dx, 0x2000
-    jne .WRAP_FAIL
-    jmp FAILURE
-.WRAP_FAIL:
-    int 0x18
-.NEXT:
-    inc ax
-    loop .MAIN
-    ret
+    mov ax, [READ_SECTORS]          ; AX = read sectors
+    mul word [BPB_bytes_per_sector] ; DX:AX = read bytes
+    add ax, LOAD_PHYS & 0xFFFF      ; DX:AX += load address = buffer address
+    adc dx, LOAD_PHYS >> 16
+    mov bx, ax                      ; BX = buffer offset
+    and bx, 0xF
+    mov cl, 12                      ; DX = buffer segment
+    shl dx, cl
+    mov cl, 4
+    shr ax, cl
+    or dx, ax
+    mov es, dx                      ; ES = DX = segment
+    pop ax                          ; Restore cluster LBA from stack in DX:AX
+    pop dx
+    pop cx                          ; Restore cluster size from stack in CX
+    call read_disk                  ; Read cluster
+    pop ax                          ; Restore current cluster number from stack
+    mov bx, 3                       ; BX = 3
+    mul bx                          ; DX:AX = AX * 3
+    dec bx                          ; BX = 2
+    div bx                          ; AX = FAT value address rel to FAT LBA
+    push dx                         ; Save remainder to stack
+    xor dx, dx                      ; DX = 0
+    div word [BPB_bytes_per_sector] ; AX:DX = FAT value seg:off rel to FAT LBA
+    push dx                         ; Save FAT value offset to stack
+    xor dx, dx                      ; DX = 0
+    add ax, [FAT_LBA]               ; DX:AX += FAT LBA = FAT value sector LBA
+    adc dx, [FAT_LBA + 2]
+    mov cx, 2                       ; sectors to read = 2
+    xor bx, bx                      ; BX = 0 (temp)
+    mov es, bx                      ; Buffer segment = BX = 0
+    mov bx, FAT_BUFFER              ; Buffer offset
+    call read_disk                  ; Read disk
+    pop bx                          ; Restore FAT value offset from stack in BX
+    mov ax, [FAT_BUFFER + bx]       ; AX = word with next cluster number
+    pop cx                          ; Restore remainder from stack in CX
+    jcxz .even                      ; AX = next cluster number
+    mov cl, 4
+    shr ax, cl
+    jmp .done
+    .even:
+    and ax, 0x0FFF
+    .done:
+    cmp ax, 0xFF7                   ; Check if EOF
+    ja .loaded                      ; Jump if EOF
+    xor bh, bh                      ; BX = sectors per cluster
+    mov bl, [BPB_sectors_per_cluster]
+    add [READ_SECTORS], bx          ; Read sectors += sectors per cluster
+    jmp .read                       ; Read next cluster
+.loaded:
+    jmp JMP_SEGMENT:JMP_OFFSET      ; Far jump to loaded file
 
-main:
-    cli
-    mov ax, 0x07C0
-    mov ds, ax
-    mov es, ax
-    ;mov fs, ax
-    ;mov gs, ax
-    mov ax, 0x0000
-    mov ss, ax
-    mov sp, 0xFFFF
-    sti
-    mov si, msgLoading
-    call Print
 
-LOAD_ROOT:
-    xor cx, cx
-    xor dx, dx
-    mov ax, 0x0020
-    mul WORD [bpbRootEntries]
-    div WORD [bpbBytesPerSector]
-    xchg ax, cx
-    mov al, BYTE [bpbNumberOfFATs]
-    mul WORD [bpbSectorsPerFAT]
-    add ax, WORD [bpbReservedSectors]
-    mov WORD [datasector], ax
-    add WORD [datasector], cx
-    mov bx, 0x0200
-    call ReadSectors
 
-    mov cx, WORD [bpbRootEntries]
-    mov di, 0x0200
-.LOOP:
-    push cx
-    mov cx, 0x000B
-    mov si, ImageName
-    push di
-    rep cmpsb
+; Inputs: DX:AX = LBA, CX = sectors to read,
+;         ES:BX = buffer address, [DISK] = disk number.
+; AX, CX, BX, DX, SI, DI are not saved, and DS is set to 0
+read_disk:
+    ; Fill out DAP structure in stack to save memory
+    xor si, si
+    push si                         ; LBA
+    push si
+    push dx
+    push ax
+    push es                         ; Buffer segment
+    push bx                         ; Buffer offset
+    push cx                         ; Number of sectors to read
+    mov si, 0x0010                  ; Structure size + reserved
+    push si
+    ; Read disk
+    mov si, sp                      ; DAP structure address = stack pointer
+    push dx                         ; Save LBA to stack
+    push ax
+    mov ah, 0x42                    ; Extended read function
+    mov dl, [DISK]                  ; Disk number
+    int 0x13                        ; BIOS disk interrupt
+    pop ax                          ; Restore LBA from stack to DX:AX
+    pop dx
+    jnc .done                       ; Jump if no errors
+    ; Error, try CHS
+    push bx                         ; Save buffer offset to stack
+    push cx                         ; Save sectors to read to stack
+    div word [BPB_sectors_per_track]; AX = LBA / sectors per track
+    inc dx                          ; DX = LBA % sectors per track + 1 = sector
+    push dx                         ; Save sector to stack
+    xor dx, dx                      ; DX = 0
+    div word [BPB_heads]            ; AX = DX:AX / heads = cylinder
+                                    ; DX = DX:AX % heads = head
+    cmp ax, 0000001111111111b       ; Error if cylinder > 1023 (CHS limit)
+    ja error
+    pop bx                          ; Restore sector from stack in BX
+    mov dh, dl                      ; DH = head
+    mov ch, al                      ; CH = cylinder (low 8 bits)
+    mov cl, 6                       ; CL = 6 (temp)
+    shl ah, cl                      ; AH << 6
+    or ah, bl                       ; AH = 2 high cylinder bits + sector
+    mov cl, ah                      ; CL = AH = 2 high cylinder bits + sector
+    pop ax                          ; Restore sectors to read from stack in AX
+    push es                         ; Save buffer segment to stack
+    push ax                         ; Save sectors to read to stack again
+    mov bx, CHS_BUFFER_SEGMENT      ; ES:BX = buffer
+    mov es, bx
+    mov bx, CHS_BUFFER_OFFSET
+    mov ah, 0x02                    ; BIOS read sectors function
+    mov dl, [DISK]                  ; Disk number
+    int 0x13                        ; BIOS disk interrupt
+    jc error                        ; If still error, jump to error code
+    pop ax                          ; Restore read sectors from stack in AX
+    mul word [BPB_bytes_per_sector] ; AX = read bytes (DX = 0)
+    mov cx, ax                      ; CX = AX = read bytes
+    pop es                          ; Restore final address from stack in ES:DI
     pop di
-    je LOAD_FAT
-    pop cx
-    add di, 0x0020
-    loop .LOOP
-    jmp FAILURE
+    mov si, CHS_BUFFER_SEGMENT      ; DS:SI = temp buffer
+    mov ds, si
+    mov si, CHS_BUFFER_OFFSET
+    rep movsb                       ; Copy CX bytes from DS:SI to ES:DI
+    mov ds, dx                      ; DS = 0 (DX == 0)
+.done:
+    add sp, 16                      ; Release stack
+    ret                             ; Return
 
-LOAD_FAT:
-    mov dx, WORD [di + 0x001A]
-    mov WORD [cluster], dx
-    xor ax, ax
-    mov al, BYTE [bpbNumberOfFATs]
-    mul WORD [bpbSectorsPerFAT]
-    mov cx, ax
-    mov ax, WORD [bpbReservedSectors]
-    mov bx, 0x0200
-    call ReadSectors
-    mov ax, 0x2000
-    mov es, ax
-    mov bx, 0x0000
-    push bx
+error:
+    mov si, msg_error           ; Point SI to error message
+    .print:
+        lodsb                   ; AL = next character from SI
+        cmp al, 0               ; Check for null terminator
+        je .done                ; Exit if null terminator
+        mov ah, 0x0E            ; Teletype output function
+        mov bh, 0x00            ; Page number
+        mov bl, 0x07            ; Text attribute (0x07 = light gray on black)
+        int 0x10                ; BIOS video interrupt
+        jmp .print              ; Continue to next character
+    .done:
+        xor ah, ah              ; Wait for keypress function
+        int 0x16                ; BIOS keyboard interrupt
+        int 0x19                ; Continue booting
 
-LOAD_IMAGE:
-    mov ax, WORD [cluster]
-    pop bx
-    call ClusterLBA
-    xor cx, cx
-    mov cl, BYTE [bpbSectorsPerCluster]
-    call ReadSectors
-    push bx
-    mov ax, WORD [cluster]
-    mov cx, ax
-    mov dx, ax
-    shr dx, 0x0001
-    add cx, dx
-    mov bx, 0x0200
-    add bx, cx
-    mov dx, WORD [bx]
-    test ax, 0x0001
-    jnz .ODD_CLUSTER
+; Filename
+filename: DB FILENAME
 
-.EVEN_CLUSTER:
-    and dx, 0000111111111111b
-    jmp .DONE
-
-.ODD_CLUSTER:
-    shr dx, 1
-    shr dx, 1
-    shr dx, 1
-    shr dx, 1
-
-.DONE:
-    mov WORD [cluster], dx
-    cmp dx, 0x0FF0
-    jb LOAD_IMAGE
-
-DONE:
-    mov si, msgCRLF
-    call Print
-    jmp 0x2000:0x0000
-    retf
-
-FAILURE:
-    mov si, msgFailure
-    call Print
-REBOOT:
-    mov ah, 0x00
-    int 0x16
-    int 0x19
-
-datasector dw 0x0000
-cluster dw 0x0000
-ImageName db "KERNEL  BIN"
-msgLoading db 0x0D, 0x0A, "Loading Boot Image ", 0x00
-msgCRLF db 0x0D, 0x0A, 0x00
-msgProgress db ".", 0x00
-msgFailure db 0x0D, 0x0A, "KERNEL.BIN not found. Press Any Key to Reboot", 0x0D, 0x0A, 0x00
-
-TIMES 510-($-$$) DB 0
-DW 0xAA55
+; Error message
+msg_error: DB "Boot error!", 0x0D, 0x0A, 0


### PR DESCRIPTION
Hello! I replaced the original x16-PRos bootloader with my own, from the FatBoot project. It supports large kernels and non-standard disk configuration (such as non-standard sector size, FATs count, or floppy geometry). Also I updated the documentation and build script.