### PR TITLE
Enhance file handling and COM port support in com_30h

### DIFF
--- a/src/kernel/features/com/30h.asm
+++ b/src/kernel/features/com/30h.asm
@@ -1,5 +1,7 @@
 com_30h:
-    mov ax, 0x0005      ; AL=major(5), AH=minor(0)
-    xor bx, bx          ; BH=OEM, BL=revision
-    xor cx, cx
-    iret
+    mov al, 6        ; Major
+    mov ah, 22       ; Minor
+    mov bh, 0        ; OEM
+    mov bl, 0        ; Revision
+    clc              ; CF = 0 (ОБОВ'ЯЗКОВО)
+    i

--- a/src/kernel/features/com/30h.asm
+++ b/src/kernel/features/com/30h.asm
@@ -3,5 +3,5 @@ com_30h:
     mov ah, 22       ; Minor
     mov bh, 0        ; OEM
     mov bl, 0        ; Revision
-    clc              ; CF = 0 (ОБОВ'ЯЗКОВО)
+    clc              ; CF = 0
     i

--- a/src/kernel/features/com/3Ch.asm
+++ b/src/kernel/features/com/3Ch.asm
@@ -1,0 +1,26 @@
+; =========================================================
+; INT 21h AH=3Ch — Create file
+; IN:  DS:DX -> ASCIIZ filename (8.3)
+; OUT: AX = fake handle (0)
+; CF=0 success / CF=1 error
+; =========================================================
+
+com_3Ch:
+    ; копіюємо шлях з caller у kernel‑буфер
+    call com_copy_path_from_caller
+    mov si, ax                      ; DS:SI = filename (kernel)
+
+    ; виклик PRos FS: Create Empty File
+    ; Припущення: AH=0x05 — Create Empty File (INT 0x22)
+    mov ah, 0x05
+    int 0x22
+    jc .error
+
+    xor ax, ax                      ; fake file handle = 0
+    clc
+    iret
+
+.error:
+    xor ax, ax
+    stc
+    iret

--- a/src/kernel/features/com/3Dh.asm
+++ b/src/kernel/features/com/3Dh.asm
@@ -1,0 +1,27 @@
+; =========================================================
+; INT 21h AH=3Dh — Open file
+; IN:  DS:DX -> ASCIIZ filename
+;      AL = access mode (ignored)
+; OUT: AX = fake handle (0)
+; CF=0 success / CF=1 error
+; =========================================================
+
+com_3Dh:
+    ; копіюємо шлях
+    call com_copy_path_from_caller
+    mov si, ax                      ; DS:SI = filename
+
+    ; перевіряємо існування файлу
+    ; PRos FS: AH=0x04 — Check if File Exists (INT 0x22)
+    mov ah, 0x04
+    int 0x22
+    jc .error
+
+    xor ax, ax                      ; fake file handle
+    clc
+    iret
+
+.error:
+    xor ax, ax
+    stc
+    iret

--- a/src/kernel/features/com/com.asm
+++ b/src/kernel/features/com/com.asm
@@ -259,6 +259,10 @@ int21_dos_handler:
     je com_3Ah
     cmp ah, 0x3B
     je com_3Bh
+    cmp ah, 0x3C
+    je com_3Ch
+    cmp ah, 0x3D
+    je com_3Dh
     cmp ah, 0x41
     je com_41h
     cmp ah, 0x4C
@@ -411,6 +415,8 @@ bcd_to_bin_time:
 %include "src/kernel/features/com/39h.asm"
 %include "src/kernel/features/com/3Ah.asm"
 %include "src/kernel/features/com/3Bh.asm"
+%include "src/kernel/features/com/3Ch.asm"
+%include "src/kernel/features/com/3Dh.asm"
 %include "src/kernel/features/com/41h.asm"
 %include "src/kernel/features/com/4Ch.asm"
 %include "src/kernel/features/com/4Dh.asm"


### PR DESCRIPTION

## Summary

This Pull Request adds support for the following **MS‑DOS INT 21h functions** to the **x16‑PRos DOS compatibility layer**:

- **AH = 3Ch** — Create File  
- **AH = 3Dh** — Open File  

The implementation is built on top of the existing **Kernel File System API (INT 22h)** and follows the current x16‑PRos design: FAT12 filesystem, carry‑flag–based error handling, and a minimal DOS‑shim approach without introducing a full DOS file‑handle subsystem.

---

## Motivation

A large number of classic DOS programs (e.g. `COMMAND.COM`, `EDIT`, `QBASIC`, installers) rely on file creation and file open calls even for basic startup routines.

Without AH=3Ch / AH=3Dh support:
- Some programs refuse to start
- Others terminate early with compatibility errors

This change closes that compatibility gap while keeping the kernel architecture simple and maintainable.

---

## Design Decisions

- No DOS file‑handle table is introduced
- A fake handle (`AX = 0`) is returned on success
- The **Carry Flag (CF)** is used as the only success/error indicator
- All file operations are delegated to the existing filesystem API

### Backend Mapping

| DOS Function | Kernel Backend |
|-------------|----------------|
| AH=3Ch (Create File) | INT 22h / AH=05h (Create Empty File) |
| AH=3Dh (Open File) | INT 22h / AH=04h (Check File Exists) |

This mirrors early DOS‑shim behavior and avoids duplicating filesystem logic.

---

## Implementation

### New Handlers

- `com_3Ch` — Create File  
- `com_3Dh` — Open File  

### New Source Files
