### PR TITLE
fix: programs/setup/install.asm:178: error: operation size not specified

### DIFF
--- a/programs/setup/install.asm
+++ b/programs/setup/install.asm
@@ -175,7 +175,7 @@ install_probe_one:
     mov ah, 0x08
     int 0x13
     mov [.bios_ah], ah
-    mov [.bios_cf], 0
+    mov byte [.bios_cf], 0
     jnc .no_cf
     mov byte [.bios_cf], 1
 .no_cf:


### PR DESCRIPTION
so, old version was giving a programs/setup/install.asm:178: error: operation size not specified. i fixed it with adding mov byte.