### PR TITLE
add: .gitignore: ignoring linux executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 
 bin/
 
+# ignoring all linux executables
+*
+!*/
+!*.*
+
 # CLion
 .idea/
 


### PR DESCRIPTION
i noticed that everyone can just add linux executables to project. now it fixed and don`t letting sneak some executables.