### PR TITLE
fix(docs): Fixed argument passing for AH=0x01 / INT 0x22

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -207,7 +207,7 @@ filenames are in 8.3 format (e.g., `FILENAME.EXT`) and converts them to uppercas
   file count.
 - **Input**:
     - `AH` = 0x01
-    - `AX` = Pointer to buffer for storing the file list (comma-separated, null-terminated)
+    - `SI` = Pointer to buffer for storing the file list (comma-separated, null-terminated)
 - **Output**:
     - `BX` = Low word of total file size (in bytes)
     - `CX` = High word of total file size (32-bit size)


### PR DESCRIPTION
This is a rather old error in the documentation. As we can see for `ah=0x01` / `int 0x22` (get file list), the argument passing is defined as: "AH = 0x01; AX = Pointer to buffer for storing the file list (comma-separated, null-terminated)." However, passing the list address this way overwrites the system call number itself. The code reveals that `SI` is actually used for passing the argument instead of `AX`.