### PR TITLE
feat(kernel): implement random API using ChaCha12 CSPRNG

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -381,6 +381,8 @@ programs=(
     "programs/print.asm PRINT.BIN"
     "programs/calendar.asm CALENDAR.BIN"
     "programs/settings.asm SETTINGS.BIN"
+    "programs/testrand.asm TESTRAND.BIN"
+    "programs/guess.asm GUESS.BIN"
 )
 
 for prog in "${programs[@]}"; do

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,6 +159,20 @@ mode (640x480, 16 colors).
 - **Error Handling**: No errors reported
 - **Notes**: Internally calls `set_video_mode` followed by `load_and_apply_theme`. If the theme file is missing or unreadable, the screen falls back to default VGA colors.
 
+### Function 0x80: Generate Random Bytes
+
+- **Description**: Generates a cryptographically secure sequence of random bytes using the ChaCha12 stream cipher.
+- **Input**:
+    - `AH` = 0x80
+    - `ES` = Segment of the destination buffer
+    - `DI` = Offset of the destination buffer
+    - `CX` = Number of bytes to generate
+- **Output**:
+    - The destination buffer at `ES:DI` is filled with `CX` random bytes.
+- **Preserves**: All registers (including `ES` and `DI`).
+- **Error Handling**: No errors reported.
+- **Notes**: Uses a 12-round ChaCha stream cipher. The state is seeded at boot time from the CMOS Real-Time Clock, BIOS timer ticks, and CPU `RDTSC` cycle counter. Implements forward secrecy by overwriting the key block after generation.
+
 ## Color Palette
 
 The following table lists the valid color codes for VGA mode 0x12 (16 colors):

--- a/programs/guess.asm
+++ b/programs/guess.asm
@@ -1,0 +1,279 @@
+; ==================================================================
+; x16-PRos - GUESS. Guess the number game.
+; Demonstrates the INT 0x21 AH = 0x80 random generation API.
+; Copyright (C) 2026 Antigravity
+; ==================================================================
+
+[BITS 16]
+[ORG 0x8000]
+
+start:
+    ; Print Game Welcome Title
+    mov ah, 0x01
+    mov si, welcome_msg
+    int 0x21
+
+.start_game:
+    ; 1. Generate a random target number between 1 and 100
+    mov ax, cs
+    mov es, ax
+    mov di, rand_byte_buf
+    mov cx, 1
+    mov ah, 0x80        ; Call random API
+    int 0x21
+
+    ; Target = (random_byte % 100) + 1
+    xor ax, ax
+    mov al, [rand_byte_buf]
+    mov bl, 100
+    div bl              ; AH = AL % 100
+    xor bx, bx
+    mov bl, ah
+    inc bl              ; BL = target number (1 to 100)
+    mov [target_num], bl
+
+    ; Reset attempt counter
+    mov dword [attempts], 0
+
+    ; Print target generation confirmation
+    mov ah, 0x01
+    mov si, gen_msg
+    int 0x21
+
+.game_loop:
+    inc dword [attempts]
+
+    ; Print guess prompt
+    mov ah, 0x01
+    mov si, prompt_msg
+    int 0x21
+
+    ; Read user guess input string
+    mov di, input_buf
+    call read_string
+
+    ; Check if ESC was pressed to exit
+    cmp byte [exit_flag], 1
+    je .exit
+
+    ; Print newline after input
+    mov ah, 0x05
+    int 0x21
+
+    ; Convert input string to number in AX
+    mov si, input_buf
+    call atoi
+
+    ; Compare AX (guess) with target_num
+    xor cx, cx
+    mov cl, [target_num]
+    cmp ax, cx
+    je .guessed_correct
+    jb .guessed_lower
+    ja .guessed_higher
+
+.guessed_lower:
+    mov ah, 0x01
+    mov si, higher_msg
+    int 0x21
+    jmp .game_loop
+
+.guessed_higher:
+    mov ah, 0x01
+    mov si, lower_msg
+    int 0x21
+    jmp .game_loop
+
+.guessed_correct:
+    mov ah, 0x01
+    mov si, correct_msg
+    int 0x21
+
+    ; Print attempt count
+    mov eax, [attempts]
+    call print_number
+
+    mov ah, 0x01
+    mov si, attempts_suffix_msg
+    int 0x21
+
+    ; Ask to play again
+    mov ah, 0x01
+    mov si, play_again_msg
+    int 0x21
+
+.read_play_again:
+    mov ah, 0
+    int 0x16            ; Read char in AL
+    cmp al, 'y'
+    je .restart
+    cmp al, 'Y'
+    je .restart
+    cmp al, 'n'
+    je .exit
+    cmp al, 'N'
+    je .exit
+    jmp .read_play_again
+
+.restart:
+    mov ah, 0x05        ; print newline
+    int 0x21
+    jmp .start_game
+
+.exit:
+    mov ah, 0x05        ; print newline
+    int 0x21
+    ret
+
+; ========================================================================
+; read_string - Reads a numeric string from keyboard with backspace support
+; IN:  ES:DI = buffer to store the string
+; OUT: String at ES:DI is null-terminated
+;      exit_flag = 1 if user pressed ESC, 0 otherwise
+; ========================================================================
+read_string:
+    pusha
+    mov byte [exit_flag], 0
+    xor cx, cx
+.read_char:
+    mov ah, 0
+    int 0x16            ; AL = ASCII, AH = Scancode
+
+    cmp al, 0x1B        ; ESC pressed?
+    je .esc_pressed
+
+    cmp al, 0x0D        ; Enter?
+    je .done
+
+    cmp al, 0x08        ; Backspace?
+    je .backspace
+
+    cmp al, '0'
+    jb .read_char
+    cmp al, '9'
+    ja .read_char
+
+    ; Echo character
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+
+    stosb
+    inc cx
+    cmp cx, 5           ; Limit input to 5 digits
+    jae .done
+    jmp .read_char
+
+.backspace:
+    test cx, cx
+    jz .read_char
+    dec di
+    dec cx
+    ; Erase on screen
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x0F
+    mov al, 0x08
+    int 0x10
+    mov al, ' '
+    int 0x10
+    mov al, 0x08
+    int 0x10
+    jmp .read_char
+
+.esc_pressed:
+    mov byte [exit_flag], 1
+
+.done:
+    mov byte [di], 0    ; Null-terminate string
+    popa
+    ret
+
+; ========================================================================
+; atoi - Converts a null-terminated digit string at DS:SI to a word in AX
+; IN:  DS:SI = pointer to string
+; OUT: AX = parsed integer
+; ========================================================================
+atoi:
+    push bx
+    push cx
+    xor dx, dx          ; DX = accumulator (result = 0)
+    xor cx, cx          ; temp digit
+.loop:
+    lodsb               ; AL = character (overwrites AL/AX)
+    test al, al
+    jz .done
+    cmp al, '0'
+    jb .done            ; Stop at non-digit
+    cmp al, '9'
+    ja .done            ; Stop at non-digit
+    sub al, '0'
+    mov cl, al          ; CL = digit
+    mov ax, dx          ; Move accumulated result to AX for mul
+    mov bx, 10
+    mul bx              ; DX:AX = AX * 10
+    add ax, cx          ; AX = AX * 10 + digit
+    mov dx, ax          ; Save result back to DX
+    jmp .loop
+.done:
+    mov ax, dx          ; Return final result in AX
+    pop cx
+    pop bx
+    ret
+
+; ========================================================================
+; print_number - Prints a 32-bit integer in EAX in base 10
+; IN:  EAX = integer value
+; OUT: Nothing (Prints characters to the console)
+; ========================================================================
+print_number:
+    pusha
+    test eax, eax
+    jnz .not_zero
+
+    mov si, zero_str
+    mov ah, 0x01
+    int 0x21
+    jmp .done
+
+.not_zero:
+    mov edi, number_buffer + 10
+    mov byte [edi], 0
+    dec edi
+    mov ebx, 10
+
+.convert_loop:
+    xor edx, edx
+    div ebx
+    add dl, '0'
+    mov [edi], dl
+    dec edi
+    test eax, eax
+    jnz .convert_loop
+
+    inc edi
+    mov si, di
+    mov ah, 0x01
+    int 0x21
+
+.done:
+    popa
+    ret
+
+welcome_msg         db '=== Guess the Number (1-100) ===', 10, 13, 'Press ESC to exit.', 10, 13, 0
+gen_msg             db 'I have generated a secret number.', 10, 13, 0
+prompt_msg          db 'Enter your guess: ', 0
+higher_msg          db 'Higher! Try again.', 10, 13, 0
+lower_msg           db 'Lower! Try again.', 10, 13, 0
+correct_msg         db 'Correct! You guessed the number in ', 0
+attempts_suffix_msg db ' attempts!', 10, 13, 0
+play_again_msg      db 'Play again? (y/n): ', 0
+zero_str            db '0', 0
+
+exit_flag           db 0
+target_num          db 0
+attempts            dd 0
+rand_byte_buf       db 0
+input_buf           times 8 db 0
+number_buffer       times 12 db 0

--- a/programs/testrand.asm
+++ b/programs/testrand.asm
@@ -1,0 +1,87 @@
+; ==================================================================
+; x16-PRos - TESTRAND. Test random number generation API.
+; Copyright (C) 2026 Antigravity
+; ==================================================================
+
+[BITS 16]
+[ORG 0x8000]
+
+start:
+    ; Print Title Message
+    mov ah, 0x01
+    mov si, title_msg
+    int 0x21
+
+    ; Request 16 random bytes from INT 0x21 AH = 0x80
+    mov ax, cs
+    mov es, ax
+    mov di, rand_buf
+    mov cx, 16
+    mov ah, 0x80
+    int 0x21
+
+    ; Print the random bytes in Hex format
+    mov cx, 16
+    mov si, rand_buf
+.hex_loop:
+    push cx
+    lodsb               ; Load AL from ds:si
+    call print_hex_byte
+    pop cx
+    loop .hex_loop
+
+    ; Print newline
+    mov ah, 0x05
+    int 0x21
+
+    ret
+
+; ========================================================================
+; print_hex_byte - Prints the byte value in AL as two hexadecimal digits
+; IN:  AL = byte value to print
+; OUT: Nothing (Prints characters to the console)
+; ========================================================================
+print_hex_byte:
+    pusha
+
+    xor dx, dx
+    mov dl, al
+
+    ; High nibble
+    shr al, 4
+    and al, 0x0F
+    cmp al, 10
+    jb .high_digit
+    add al, 'A' - 10 - '0'
+.high_digit:
+    add al, '0'
+    mov [char_buf], al
+    mov si, char_buf
+    mov ah, 0x01
+    int 0x21
+
+    ; Low nibble
+    mov al, dl
+    and al, 0x0F
+    cmp al, 10
+    jb .low_digit
+    add al, 'A' - 10 - '0'
+.low_digit:
+    add al, '0'
+    mov [char_buf], al
+    mov si, char_buf
+    mov ah, 0x01
+    int 0x21
+
+    ; Space
+    mov byte [char_buf], ' '
+    mov si, char_buf
+    mov ah, 0x01
+    int 0x21
+
+    popa
+    ret
+
+title_msg db 'Random 16 bytes: ', 0
+char_buf  db 0, 0
+rand_buf  times 16 db 0

--- a/src/kernel/features/api/api_output.asm
+++ b/src/kernel/features/api/api_output.asm
@@ -76,6 +76,8 @@ int21_handler:
     je .get_date
     cmp ah, 0x0C
     je .clear_screen_themed
+    cmp ah, 0x80
+    je .random_bytes
     jmp .done
 
 .init:
@@ -168,6 +170,14 @@ int21_handler:
     mov dh, [timezone_local_month]
     mov dl, [timezone_local_day]
     mov [bp+14], dx
+    jmp .done
+
+.random_bytes:
+    mov bp, sp
+    mov es, [bp + 0]     ; Load caller's ES from stack (pushed by 'push es')
+    mov di, [bp + 4]     ; Load caller's DI from stack (pushed by 'pusha')
+    mov cx, [bp + 16]    ; Load caller's CX from stack (pushed by 'pusha')
+    call api_random_generate
     jmp .done
 
 .done:

--- a/src/kernel/features/api/api_random.asm
+++ b/src/kernel/features/api/api_random.asm
@@ -1,0 +1,358 @@
+; ==================================================================
+; x16-PRos - Kernel Random API (ChaCha20-based CSPRNG)
+; Copyright (C) 2026 Antigravity
+; ==================================================================
+
+[BITS 16]
+
+section .data
+random_initialized db 0
+
+section .bss
+random_state      resd 16
+random_keystream  resd 16
+
+section .text
+
+; ========================================================================
+; chacha20_quarter_round - Performs the ChaCha20 quarter-round on 4 dwords
+; IN:  EAX = word a
+;      EBX = word b
+;      ECX = word c
+;      EDX = word d
+; OUT: EAX, EBX, ECX, EDX = updated words a, b, c, d
+; ========================================================================
+chacha20_quarter_round:
+    add eax, ebx
+    xor edx, eax
+    rol edx, 16
+
+    add ecx, edx
+    xor ebx, ecx
+    rol ebx, 12
+
+    add eax, ebx
+    xor edx, eax
+    rol edx, 8
+
+    add ecx, edx
+    xor ebx, ecx
+    rol ebx, 7
+    ret
+
+; ========================================================================
+; chacha20_double_round - Performs the ChaCha20 double-round (column + diagonal)
+; IN:  SI = pointer to the 16-dword state matrix
+; OUT: State matrix at SI updated in-place
+; ========================================================================
+chacha20_double_round:
+    push si
+
+    ; Column 0: 0, 4, 8, 12
+    mov eax, [si + 0]
+    mov ebx, [si + 16]
+    mov ecx, [si + 32]
+    mov edx, [si + 48]
+    call chacha20_quarter_round
+    mov [si + 0], eax
+    mov [si + 16], ebx
+    mov [si + 32], ecx
+    mov [si + 48], edx
+
+    ; Column 1: 1, 5, 9, 13
+    mov eax, [si + 4]
+    mov ebx, [si + 20]
+    mov ecx, [si + 36]
+    mov edx, [si + 52]
+    call chacha20_quarter_round
+    mov [si + 4], eax
+    mov [si + 20], ebx
+    mov [si + 36], ecx
+    mov [si + 52], edx
+
+    ; Column 2: 2, 6, 10, 14
+    mov eax, [si + 8]
+    mov ebx, [si + 24]
+    mov ecx, [si + 40]
+    mov edx, [si + 56]
+    call chacha20_quarter_round
+    mov [si + 8], eax
+    mov [si + 24], ebx
+    mov [si + 40], ecx
+    mov [si + 56], edx
+
+    ; Column 3: 3, 7, 11, 15
+    mov eax, [si + 12]
+    mov ebx, [si + 28]
+    mov ecx, [si + 44]
+    mov edx, [si + 60]
+    call chacha20_quarter_round
+    mov [si + 12], eax
+    mov [si + 28], ebx
+    mov [si + 44], ecx
+    mov [si + 60], edx
+
+    ; Diagonal 1: 0, 5, 10, 15
+    mov eax, [si + 0]
+    mov ebx, [si + 20]
+    mov ecx, [si + 40]
+    mov edx, [si + 60]
+    call chacha20_quarter_round
+    mov [si + 0], eax
+    mov [si + 20], ebx
+    mov [si + 40], ecx
+    mov [si + 60], edx
+
+    ; Diagonal 2: 1, 6, 11, 12
+    mov eax, [si + 4]
+    mov ebx, [si + 24]
+    mov ecx, [si + 44]
+    mov edx, [si + 48]
+    call chacha20_quarter_round
+    mov [si + 4], eax
+    mov [si + 24], ebx
+    mov [si + 44], ecx
+    mov [si + 48], edx
+
+    ; Diagonal 3: 2, 7, 8, 13
+    mov eax, [si + 8]
+    mov ebx, [si + 28]
+    mov ecx, [si + 32]
+    mov edx, [si + 52]
+    call chacha20_quarter_round
+    mov [si + 8], eax
+    mov [si + 28], ebx
+    mov [si + 32], ecx
+    mov [si + 52], edx
+
+    ; Diagonal 4: 3, 4, 9, 14
+    mov eax, [si + 12]
+    mov ebx, [si + 16]
+    mov ecx, [si + 36]
+    mov edx, [si + 56]
+    call chacha20_quarter_round
+    mov [si + 12], eax
+    mov [si + 16], ebx
+    mov [si + 36], ecx
+    mov [si + 56], edx
+
+    pop si
+    ret
+
+; ========================================================================
+; chacha20_hash - Performs the ChaCha12 block hash function (12 rounds)
+; IN:  SI = pointer to input state (64 bytes)
+;      DI = pointer to output buffer (64 bytes)
+; OUT: Output buffer at DI filled with hashed state + original state
+; ========================================================================
+chacha20_hash:
+    pusha
+
+    ; Copy input state SI to output state DI
+    mov cx, 16
+    xor bx, bx
+.copy_loop:
+    mov eax, [si + bx]
+    mov [di + bx], eax
+    add bx, 4
+    loop .copy_loop
+
+    ; Run 6 double rounds on the output state (DI) for ChaCha12
+    push si
+    mov si, di
+    mov cx, 6
+.round_loop:
+    push cx
+    call chacha20_double_round
+    pop cx
+    loop .round_loop
+    pop si
+
+    ; Add back original state SI to output state DI
+    mov cx, 16
+    xor bx, bx
+.add_loop:
+    mov eax, [si + bx]
+    add [di + bx], eax
+    add bx, 4
+    loop .add_loop
+
+    popa
+    ret
+
+; ========================================================================
+; api_random_init - Seeds and scrambles the global ChaCha20 state
+; IN:  Nothing
+; OUT: Nothing (Updates random_state and sets random_initialized flag)
+; ========================================================================
+api_random_init:
+    pusha
+    push ds
+
+    mov ax, cs
+    mov ds, ax
+
+    ; 1. Set Constants (words 0-3)
+    mov dword [random_state + 0],  0x61707865 ; "expa"
+    mov dword [random_state + 4],  0x3320646e ; "nd 3"
+    mov dword [random_state + 8],  0x79622d32 ; "2-by"
+    mov dword [random_state + 12], 0x6b206574 ; "te k"
+
+    ; 2. Read BIOS Timer Tick (0040:006C) into word 4
+    push ds
+    mov ax, 0x0040
+    mov ds, ax
+    mov eax, [0x006C]
+    pop ds
+    mov [random_state + 16], eax
+
+    ; 3. Read RDTSC into words 5 and 6
+    rdtsc
+    mov [random_state + 20], eax
+    mov [random_state + 24], edx
+
+    ; 4. Read CMOS clock into words 7 and 8
+    call timezone_get_local_datetime
+    mov al, [timezone_local_hour]
+    mov ah, [timezone_local_minute]
+    shl eax, 16
+    mov al, [timezone_local_second]
+    mov ah, [timezone_local_century]
+    mov [random_state + 28], eax
+
+    mov al, [timezone_local_year]
+    mov ah, [timezone_local_month]
+    shl eax, 16
+    mov al, [timezone_local_day]
+    mov ah, 0 ; padding
+    mov [random_state + 32], eax
+
+    ; 5. Read SP & CS into word 9
+    mov ax, sp
+    mov dx, cs
+    shl eax, 16
+    mov ax, dx
+    mov [random_state + 36], eax
+
+    ; 6. Read another RDTSC into word 10
+    rdtsc
+    mov [random_state + 40], eax
+
+    ; 7. Set fixed salt into word 11
+    mov dword [random_state + 44], 0xDEADBEEF
+
+    ; 8. Clear block counter (words 12-13)
+    mov dword [random_state + 48], 0
+    mov dword [random_state + 52], 0
+
+    ; 9. Set IV (words 14-15) from high part of RDTSC
+    mov [random_state + 56], edx
+    rdtsc
+    mov [random_state + 60], eax
+
+    ; 10. Scramble initial state using chacha20_hash
+    mov si, random_state
+    mov di, random_keystream
+    call chacha20_hash
+
+    ; 11. Feed back scrambled output to set final key and IV
+    mov cx, 8
+    xor bx, bx
+.feed_key:
+    mov eax, [random_keystream + bx]
+    mov [random_state + 16 + bx], eax
+    add bx, 4
+    loop .feed_key
+
+    mov eax, [random_keystream + 32]
+    mov [random_state + 56], eax
+    mov eax, [random_keystream + 36]
+    mov [random_state + 60], eax
+
+    ; 12. Clear block counter again
+    mov dword [random_state + 48], 0
+    mov dword [random_state + 52], 0
+
+    mov byte [random_initialized], 1
+
+    pop ds
+    popa
+    ret
+
+; ========================================================================
+; api_random_generate - Generates random bytes to satisfy user buffer request
+; IN:  ES:DI = buffer pointer in user segment
+;      CX = request size in bytes
+; OUT: Buffer filled with random bytes
+; ========================================================================
+api_random_generate:
+    pusha
+    push ds
+    push es
+
+    mov ax, cs
+    mov ds, ax
+
+    ; Save caller's destination pointer DI to DX
+    mov dx, di
+
+    cmp byte [random_initialized], 0
+    jne .generate_loop
+    call api_random_init
+
+.generate_loop:
+    cmp cx, 0
+    je .done
+
+    ; Generate 64-byte block
+    mov si, random_state
+    mov di, random_keystream
+    call chacha20_hash
+
+    ; Increment 64-bit block counter (words 12-13)
+    add dword [random_state + 48], 1
+    adc dword [random_state + 52], 0
+
+    ; Copy up to 32 bytes of user data per block
+    mov bx, 32
+    cmp cx, bx
+    jae .copy_size_ok
+    mov bx, cx
+.copy_size_ok:
+
+    push cx
+    push si
+    push di
+    mov cx, bx
+    mov si, random_keystream
+    add si, 32
+    mov di, dx              ; Restore destination pointer from DX
+.copy_bytes:
+    lodsb
+    stosb
+    loop .copy_bytes
+    mov dx, di              ; Save updated destination pointer back to DX
+    pop di
+    pop si
+    pop cx
+
+    sub cx, bx
+
+    ; Update key with first 32 bytes of output block
+    push cx
+    mov cx, 8
+    xor bx, bx
+.update_key:
+    mov eax, [random_keystream + bx]
+    mov [random_state + 16 + bx], eax
+    add bx, 4
+    loop .update_key
+    pop cx
+
+    jmp .generate_loop
+
+.done:
+    pop es
+    pop ds
+    popa
+    ret

--- a/src/kernel/features/com/com.asm
+++ b/src/kernel/features/com/com.asm
@@ -267,6 +267,13 @@ int21_dos_handler:
     je com_4Dh
     cmp ah, 0x54
     je com_54h
+    cmp ah, 0x80
+    je com_80h
+    iret
+
+com_80h:
+    call api_random_generate
+    clc
     iret
 
 

--- a/src/kernel/init.asm
+++ b/src/kernel/init.asm
@@ -69,6 +69,11 @@ init_api:
 
     mov si, api_fs_init_msg
     call log_okay
+
+    call api_random_init
+
+    mov si, api_random_init_msg
+    call log_okay
     ret
 
 init_configs:
@@ -984,6 +989,7 @@ timer_init_msg           db 'Timer initialization', 0
 api_init_msg             db 'API initialization', 0
 api_output_init_msg      db 'Output API (INT 0x21)', 0
 api_fs_init_msg          db 'File System API (INT 0x22)', 0
+api_random_init_msg      db 'Random API (ChaCha12)', 0
 config_init_msg          db 'Configuration loading', 0
 display_init_msg         db 'Display initialization', 0
 mouse_init_msg           db 'Mouse driver loaded', 0

--- a/src/kernel/kernel.asm
+++ b/src/kernel/kernel.asm
@@ -2171,6 +2171,7 @@ rip_terry:
 ; ====== API ======
 %INCLUDE "src/kernel/features/api/api_output.asm"
 %INCLUDE "src/kernel/features/api/api_fs.asm"
+%INCLUDE "src/kernel/features/api/api_random.asm"
 ; =================
 
 ; ===================== Data Section =====================


### PR DESCRIPTION
**Description:**
Implemented a cryptographically secure pseudo-random number generator (CSPRNG) API based on the ChaCha12 (more would be too heavy for a 16-bit system, but it can be changed to standard 20) stream cipher. The API is routed via the software interrupt INT 0x21 under function code AH = 0x80. It provides a high-quality entropy source for user-space applications, seeded at boot time from the CMOS Real-Time Clock, BIOS timer ticks, and CPU RDTSC cycle counter. It also incorporates forward secrecy by overwriting the key block after each generation.

Along with the kernel API, a hex verification tool (TESTRAND.BIN) and an interactive text-based "Guess the Number" game (GUESS.BIN) have been added to demonstrate and verify the functionality.

**Steps to Reproduce:** (Verification instructions)
1. Start the OS by running ./run-linux.sh
2. Run the verification command: TESTRAND
3. Observe 16 unique, random hex bytes printed on the screen (each run yields different, non-repeating sequences).
4. Run the demo game command: GUESS
5. Play the game, verifying correct parsing of inputs, higher/lower hints, and the ability to exit instantly by pressing the ESC key.

**Expected Behavior:**
Calling INT 0x21 with AH = 0x80 should generate and write CX random bytes to the destination buffer at ES:DI. The returned bytes should be cryptographically random and change uniquely on subsequent system calls.

**Actual Behavior:**
The OS did not have a unified system random API, forcing applications to implement custom unseeded linear congruential generators (LCG) or raw port reads.

**Environment:**
- x16-PRos version: 0.5.9s
- Emulator: QEMU 8.0