### PR TITLE
Global update: memory protection, DOS compatibility, EN/RU keyboard layout, and stability

### DIFF
--- a/ASM_DEV_SKILL.md
+++ b/ASM_DEV_SKILL.md
@@ -1,0 +1,168 @@
+# x16-PRos — Assembly Development Guide & Session Retrospective
+
+Authoritative developer guide for writing x86 (16-bit real mode) NASM code for
+x16-PRos. Replaces the former `.kilo/skills/x86-nasm-real-mode/SKILL.md` and is
+kept in the repository root so it is versioned with the code.
+
+---
+
+## 1. Golden rules (do this)
+
+1. **Use NASM labels, never hand-computed offsets.** NASM resolves every
+   `mov ax, my_var` / `call my_func` for you. Hand-picking binary offsets for
+   debugging is slow and error-prone (see Retrospective #4).
+2. **Debug variables go in kernel `.data`/`.bss`, never in working buffers.**
+   `disk_buffer` (0x2000:0xE000), `dirlist` (0x2000:0xA800) and `command_history`
+   (0x2000:0xD000) are overwritten by disk I/O — a counter written there reads
+   back as garbage and wastes hours (Retrospective #3).
+3. **Respect the real-mode vector map.** Vectors `0x08..0x0F` are hardware IRQs:
+   0x08=timer, 0x09=keyboard, 0x0E=floppy. Never install "exception" handlers
+   there — #PF/#GP only exist in protected mode. Only `0x00` (#DE) and `0x06`
+   (#UD) are pure real-mode exceptions (Retrospective #2).
+4. **Chain BIOS hooks with `pushf; call far [old_vector]`.** This is the standard
+   TSR pattern and it works (INT 0x16 layout translation uses it). After the old
+   handler returns, DS/ES may be clobbered — restore `DS=0x2000` before touching
+   any kernel variable.
+5. **Return CF/ZF through `iret` by patching the saved flags on the stack.**
+   `iret` restores the caller's flags, so `clc; iret` is a no-op for CF. Use
+   `mov bp, sp` then `or/and word [bp + 4 + 2*N], 0x0001/0xFFFE` where `N` is the
+   number of pushes in the handler (see `com/handles.asm` macros).
+6. **Always EOI the PIC when doing work from a hardware-interrupt context.**
+   The INT 0x1C timer hook aborts from inside the BIOS INT 8; without
+   `out 0x20, al` (EOI, AL=0x20) the timer IRQ stays pending and the clock stops.
+7. **Bound every buffer.** Strings copied from callers are capped at 63 bytes
+   (`api_output.asm`/`api_fs.asm`). DOS file handles cap writes to the 16 KiB
+   buffer (`com_40h`). Path components are capped at 14 (`cd_command`). Check
+   every new copy/write against its destination size.
+8. **Load big files into `0x3000` (DATA_LOAD_SEG), never into 0x2000/0x1000.**
+   Files > 32 KiB loaded at `0x1000:0x8000` wrap into the kernel segment and the
+   `FS_CHECK_DEST` guard rejects them; `cat`/`copy` already use `0x3000`.
+9. **Test after full boot.** QEMU boot takes ~18 s; sending keys earlier means
+   they sit in the BIOS buffer and make input look broken (Retrospective #12).
+10. **Verify the floppy image first** when the bootloader "cannot find
+    KERNEL.BIN" — check the FAT12 builder (root directory, FAT chain, boot
+    sector) before suspecting the bootloader or QEMU (Retrospective #1).
+11. **Follow CONTRIBUTING.md**: lowercase function names, UPPERCASE constants,
+    lowercase variables, 4-space indent, function doc headers `; ===…===`,
+    English comments. The only accepted non-English exception is the Cyrillic
+    characters in `ru_layout_table` (they document the mapped characters).
+
+## 2. Never do this
+
+1. `mov ss, sp` style stack setup without a stack segment (tbasic bug) —
+   `SS=0` + deep stack grows into the IVT/BDA. Set `SS` explicitly.
+2. `int 0x19` to exit a program — that reboots the machine. BIN programs exit
+   with a near `ret` (trampoline returns to the shell).
+3. Direct port reads like `in al, 0x60` for the keyboard — they steal scan codes
+   from the BIOS buffer and desync IRQ1. Use `INT 0x16`.
+4. `jmp $` busy-waits / infinite loops in programs (tetris `game_over`).
+5. Unbalanced pushes before a jump out of scope (mine `DetectWin`).
+6. `mov ax, 4C00h; int 21h` to exit a BIN program — AH=4Ch is not a PRos BIN
+   function; execution falls into garbage. Use `ret`.
+7. Overwrite a file silently when it exceeds a buffer (hexedit/write) — fail
+   with a message instead.
+8. Scale 16-bit addresses (`[bx*2]`, `[sp+16]`, `[dx+label]`): 16-bit addressing
+   allows only BX/BP/SI/DI without scaling, and SP cannot be a base register.
+9. Use `Ctrl+Alt+Del` as a custom hotkey — the BIOS intercepts it for reboot.
+   `Ctrl+Shift+F1` is the safe choice.
+10. Store local data labels at the end of a file — `.size` etc. bind to the last
+    non-local label (`print_char.size`) and break references from earlier code.
+    Use global names for module-level data.
+11. Assume QEMU screenshots are reliable — `screendump` on QEMU 11 is flaky and
+    hangs intermittently. Use QMP `pmemsave`/`xp` for deterministic checks.
+12. Write a caller buffer using the caller's DS without saving it — handlers
+    entered via INT have the program's DS; always `push ds` and restore.
+
+## 3. Memory map (kernel constants)
+
+| Segment:Offset | Purpose |
+|---|---|
+| 0x0000:0x0000 | IVT (int20/int21/int22 hooks; fault hooks on 0x00/0x06) |
+| 0x1000:0x0000 | CP866 font / CFG scratch (CFG_SCRATCH_OFF = 0x1000) |
+| 0x1000:0x8000 | BIN program entry (PROGRAM_LOAD_SEG:PROGRAM_LOAD_OFF); thunk at 0x7FF0; params at 0x7F00 |
+| 0x2000:0x0000 | Kernel code+data+bss (must end below 0xA800) |
+| 0x2000:0xA800 | dirlist / 0xD000 history / 0xE000 disk_buffer |
+| 0x2FC0:0x0100 | COM programs (stack 0x2FC0:0xFFFE, exit via INT 0x20) |
+| 0x3000:0x0000 | DATA_LOAD / BMP / IMF (safe big-file area) |
+| 0x3010:0x0000 | EXE load segment (image ≤ 0xC000) |
+| 0x4000:0x0000 | DOS file-handle buffers (4 × 16 KiB) |
+| SS=0, SP=0xFFFF | Kernel stack (keep recursion shallow) |
+
+`current_program_type`: 0 = shell, 1 = BIN/PLE, 2 = COM/EXE. Used by the
+Ctrl+Shift+F1 abort (INT 0x16 hook + INT 0x1C backup).
+
+## 4. ABI for programs
+
+- **BIN** (0x1000:0x8000): must end with a balanced near `ret`. Params at
+  `0x1000:0x7F00` (SI points there on entry).
+- **COM** (0x2FC0:0x0100): exit with `INT 0x20` (offset 0 contains `CD 20`) or
+  `int 21h ah=4Ch`. PS/2 mouse is disabled for programs.
+- **EXE** (0x3010): MZ header validated; relocations bounded to the image.
+- **PLE**: custom format, must call `api_dos_init` before INT 0x21.
+- Kernel API: `INT 0x21` = output (PRos), `INT 0x22` = filesystem. During
+  COM/EXE the DOS `INT 0x21` handler is active (file handles 3Ch..42h, 2Eh, 43h,
+  56h).
+- `Ctrl+Shift+F1` aborts any running program back to the shell; `Ctrl+Shift`
+  toggles the RU/EN layout.
+
+## 5. Workflow
+
+1. Read the affected file first; note which segment DS/ES/SS point to at the
+   edit point (kernel = 0x2000; after `mov ds, <prog_seg>` everything is
+   relative).
+2. Follow the flag convention: CF=0 success / CF=1 error; results in AX/BX/DX.
+   Document IN/OUT in the doc header.
+3. Bound every length read from disk/config/user input.
+4. Never trust file-derived pointers (FAT chains, MZ reloc table, PLE segments).
+5. Build/test on Windows with `tools/build_test.ps1` + `tools/qemu_test.py`
+   (QMP). Wait ~18 s for full boot before sending keys.
+6. Keep `kernel_end` below 0xA800; the kernel was ~37 KB of a 43 KB budget.
+
+## 6. Session retrospective — mistakes made and lessons learned
+
+1. **Broken FAT12 builder caused hours of "bootloader debugging".** The
+   `build_image.py` placed root files into a nonexistent `""` directory, so the
+   bootloader never found KERNEL.BIN. The mistake was assuming the bootloader/
+   QEMU was wrong instead of verifying the image first. Lesson: validate the
+   image (root dir, FAT, boot sector) before anything else.
+2. **Overwrote vector 0x0E (IRQ6 / floppy) with a "#PF" handler.** In real mode
+   vectors 0x08..0x0F are hardware IRQs; the floppy read hung. Lesson: only
+   0x00 (#DE) and 0x06 (#UD) are safe to hook in real mode.
+3. **Debug counters placed inside `disk_buffer`** (0x2000:0xF000) read back as
+   zeros because disk I/O overwrites them — led to false conclusions that the
+   BIOS "did not preserve DS". Lesson: debug state lives in `.data`/`.bss`.
+4. **Hand-derived variable offsets were repeatedly wrong.** `current_program_type`
+   vs `autocomplete_enabled` confusion; kernel size changes shifted offsets
+   between builds. Lesson: use NASM labels; find addresses via the disassembly
+   of the *specific* instruction, not guessing.
+5. **Rewrote a working INT 0x16 hook (pushf/call far) into a BDA reader** based
+   on the bad debug data, which broke multi-key input and crashed into the video
+   BIOS. Reverting to `pushf; call far` + restoring DS fixed it. Lesson: don't
+   replace a working mechanism on shaky evidence.
+6. **Ctrl+Alt+Del is intercepted by the BIOS** (warm reboot); the abort hotkey
+   had to become Ctrl+Shift+F1. Lesson: check BIOS-intercepted keys.
+7. **16-bit addressing pitfalls repeated:** `[sp+16]`, `[bx*2]`, `[dx+label]`
+   are invalid; only BX/BP/SI/DI without scaling, SP not a base.
+8. **Local data labels at EOF** (`.size`, `.seconds`) bound to the last function
+   and produced `symbol not defined`. Lesson: global names for module data.
+9. **CF via `clc; iret` is a no-op** — the flags must be patched on the saved
+   stack word. Discovered while implementing the DOS file-handle layer.
+10. **QEMU 11 `screendump` is flaky** and hangs after repeated calls; switching
+    to QMP (`pmemsave`, `xp`, `screendump` via QMP) made verification
+    deterministic.
+11. **Boot is slow (~18 s)**; tests typed commands before the shell was ready and
+    misread the result as broken input. Lesson: wait for full boot.
+12. **The EOI gap:** the timer hook aborted from inside INT 8 without
+    acknowledging the PIC, which would stop the system clock. Fixed with
+    `out 0x20, al`.
+13. **The DOS write path lacked a size cap** (com_40h could overflow a handle
+    buffer); fixed to cap at the free space.
+
+## 7. Key reference points
+
+- OSDev Wiki: real mode, FAT12, MZ format — https://wiki.osdev.org
+- NASM manual: https://nasm.us/doc/
+- Repo docs: `docs/API.md`, `docs/CONFIGURATION.md`, `CONTRIBUTING.md`,
+  `src/kernel/MEM_MAP.TXT`
+- Test tooling: `tools/build_test.ps1`, `tools/qemu_test.py`,
+  `tools/qemu_debug.py`, `tools/build_image.py`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ Thanks to everyone who supported me financially. All your nicknames will appear 
 
 ## Key Features
 
+<<<<<<< HEAD
 - **MS-DOS Compatibility**: Native support for running standard MS-DOS `.COM` and `.EXE` executables.
+=======
+- **MS-DOS Compatibility**: Native support for running standard MS-DOS `.COM` and `.EXE` executables, plus DOS file-handle API (`INT 0x21`: create/open/close/read/write/seek, rename).
+>>>>>>> 88a7da6 (Первый коммит)
 - **Encrypted Password System**: XOR-based password encryption with custom key
 - **User Authentication**: Login system with configurable user account
 - **Password Protection**: Encrypted PASSWORD.CFG prevents plaintext password storage
@@ -123,6 +127,10 @@ The system includes a powerful terminal - **PRos Terminal**. It not only allows 
 |---------|--------|-------------|
 | `dir` | `dir` | List files in current directory with size info |
 | `cat` | `cat <filename>` | Display file contents |
+<<<<<<< HEAD
+=======
+| `type` | `type <filename>` | Alias of `cat` |
+>>>>>>> 88a7da6 (Первый коммит)
 | `size` | `size <filename>` | Show file size in bytes |
 | `del` | `del <filename>` | Delete a file (kernel.bin protected) |
 | `copy` | `copy <source> <dest>` | Copy file (root directory only) |
@@ -136,6 +144,22 @@ The system includes a powerful terminal - **PRos Terminal**. It not only allows 
 | `cd` | `cd <dirname>` | Change directory (use `..` for parent, `/` for root) |
 | `mkdir` | `mkdir <dirname>` | Create new directory |
 | `deldir` | `deldir <dirname>` | Delete empty directory |
+<<<<<<< HEAD
+=======
+| `pwd` | `pwd` | Print the current working directory |
+| `ls` | `ls` | Alias of `dir` |
+| `md` | `md <dirname>` | Alias of `mkdir` |
+| `rd` | `rd <dirname>` | Alias of `deldir` |
+
+#### Keyboard Layout
+| Command | Description |
+|---------|-------------|
+| `layout` | Toggle EN/RU keyboard layout |
+| `layout ru` | Switch to the Russian (JCUKEN) layout |
+| `layout en` | Switch to the English layout |
+| `Ctrl+Shift` | Toggle the layout while typing |
+| `Ctrl+Shift+F1` | Close the running program and return to the shell |
+>>>>>>> 88a7da6 (Первый коммит)
 
 #### Media & Display
 | Command | Syntax | Description |
@@ -268,7 +292,11 @@ x16-PRos includes a comprehensive collection of built-in applications:
 <td width="33%" align="center">
     <br>
     <b>And more...</b><br>
+<<<<<<< HEAD
     SNAKE.BIN, CREDITS.BIN, AUTOEXEC.BIN, GREP.BIN, HEAD, TAIL, THEME.BIN, CHARS.BIN, WAVPLAY.BIN, FDISK.BIN, ED.BIN, HELLO.COM, FRACTAL.COM, CALENDAR.BIN
+=======
+    SNAKE.BIN, CREDITS.BIN, AUTOEXEC.BIN, GREP.BIN, HEAD, TAIL, THEME.BIN, CHARS.BIN, WAVPLAY.BIN, FDISK.BIN, ED.BIN, HELLO.COM, FRACTAL.COM, CALENDAR.BIN, DUMP.BIN, UPTIME.BIN
+>>>>>>> 88a7da6 (Первый коммит)
   </td>
 </tr>
 </table>

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 #!/bin/bash
+=======
+﻿#!/bin/bash
+>>>>>>> 88a7da6 (Первый коммит)
 
 # ==================================================================
 # x16-PRos -- The x16-PRos build script for Linux
@@ -366,6 +370,10 @@ programs=(
     "programs/procentc.asm PROCENTC.BIN"
     "programs/paint.asm PAINT.BIN"
     "programs/pong.asm PONG.BIN"
+<<<<<<< HEAD
+=======
+    "programs/flappy.asm FLAPPY.BIN"
+>>>>>>> 88a7da6 (Первый коммит)
     "programs/hexedit.asm HEXEDIT.BIN"
     "programs/clock.asm CLOCK.BIN"
     "programs/mandel.asm MANDEL.BIN"
@@ -380,6 +388,11 @@ programs=(
     "programs/tree.asm TREE.BIN"
     "programs/print.asm PRINT.BIN"
     "programs/calendar.asm CALENDAR.BIN"
+<<<<<<< HEAD
+=======
+    "programs/dump.asm DUMP.BIN"
+    "programs/uptime.asm UPTIME.BIN"
+>>>>>>> 88a7da6 (Первый коммит)
     "programs/settings.asm SETTINGS.BIN"
 )
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -415,4 +415,51 @@ filenames are in 8.3 format (e.g., `FILENAME.EXT`) and converts them to uppercas
 The x16-PRos operating system and its API are licensed under the MIT License. See the LICENSE.TXT for details.
 
 **Author**: PRoX (https://github.com/PRoX2011)
+<<<<<<< HEAD
 **Version**: 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
+=======
+**Version**: 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
+---
+
+## INT 0x21 - MS-DOS Compatibility API
+
+During COM and EXE program execution the kernel installs a DOS-compatible
+INT 0x21 handler. It implements the classic MS-DOS functions on top of the
+PRos file system so DOS programs can create, open, read, write and seek
+files:
+
+| AH | Function | Input | Output |
+|----|----------|-------|--------|
+| 0x2E | Set/Reset verify flag | AL = 0/1 | - |
+| 0x3C | Create file | DS:DX = name, CX = attr | AX = handle |
+| 0x3D | Open file | DS:DX = name, AL = mode | AX = handle |
+| 0x3E | Close file | BX = handle | - |
+| 0x3F | Read file | BX = handle, CX = count, DS:DX = buffer | AX = bytes read |
+| 0x40 | Write file | BX = handle, CX = count, DS:DX = buffer | AX = bytes written |
+| 0x42 | Seek | BX = handle, CX:DX = offset, AL = origin | DX:AX = new position |
+| 0x43 | Get/set attribute | DS:DX = name, AL = 0/1 | CX = attribute |
+| 0x56 | Rename file | DS:DX = old name, ES:DI = new name | - |
+
+- **Handles**: up to 4 files open simultaneously; each file is loaded into a
+  private 16 KiB buffer (segment 0x4000). Reads/writes operate on the memory
+  copy; Close writes the buffer back to disk when modified.
+- **Errors**: CF = 1 with an error code in AX (2 = file not found,
+  3 = path not found, 4 = too many open files, 6 = invalid handle).
+- **Seek origins**: 0 = start, 1 = current, 2 = end. Only 16-bit offsets
+  are supported (CX = 0).
+
+---
+
+## Terminal Commands Added
+
+| Command | Description |
+|---------|-------------|
+| `LAYOUT [EN|RU]` | Switch the keyboard layout (EN / Russian) |
+| `PWD` | Print the current working directory |
+| `LS` | Alias of DIR |
+| `MD` | Alias of MKDIR |
+| `RD` | Alias of DELDIR |
+| `TYPE` | Alias of CAT |
+| `Ctrl+Shift` | Toggle keyboard layout while typing |
+| `Ctrl+Shift+F1` | Close the running program and return to the shell |
+>>>>>>> 88a7da6 (Первый коммит)

--- a/programs/brainf.asm
+++ b/programs/brainf.asm
@@ -63,11 +63,19 @@ getInput:
     cmp al, 08h
     je .handle_backspace
 
+<<<<<<< HEAD
     stosb
 
     cmp al, 0Dh
     je allocateWorkspace
 
+=======
+    cmp al, 0Dh
+    je allocateWorkspace
+
+    stosb
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov ah, 09h
     int 10h
 

--- a/programs/calendar.asm
+++ b/programs/calendar.asm
@@ -170,6 +170,7 @@ zeller:
     xor ah, ah
     mov [.t], ax
 
+<<<<<<< HEAD
     mov ax, [.k]
     shr ax, 2
     add ax, [.t]
@@ -177,6 +178,27 @@ zeller:
     add ax, [.j]
     add ax, 5
 
+=======
+    ; h = (q + 13(m+1)/5 + K + K/4 + J/4 + 5J) mod 7, q = 1 (first day)
+    mov ax, [.k]
+    shr ax, 2
+    mov [.sum], ax          ; K/4
+    mov ax, [.t]
+    add [.sum], ax          ; + 13(m+1)/5
+    mov ax, [.k]
+    add [.sum], ax          ; + K
+    mov ax, [.j]
+    shr ax, 1
+    shr ax, 1
+    add [.sum], ax          ; + J/4
+    mov ax, [.j]
+    mov cx, 5
+    mul cx
+    add [.sum], ax          ; + 5J
+    inc word [.sum]         ; + q = 1
+
+    mov ax, [.sum]
+>>>>>>> 88a7da6 (Первый коммит)
     xor dx, dx
     mov cx, 7
     div cx
@@ -192,6 +214,10 @@ zeller:
 .j dw 0
 .k dw 0
 .t dw 0
+<<<<<<< HEAD
+=======
+.sum dw 0
+>>>>>>> 88a7da6 (Первый коммит)
 
 draw_header:
     mov dh, 0

--- a/programs/dump.asm
+++ b/programs/dump.asm
@@ -1,0 +1,161 @@
+; ==================================================================
+; x16-PRos - DUMP.BIN. Hexadecimal file dump utility.
+; Usage: DUMP <filename>
+; Shows the file contents as hex bytes with offsets.
+; ==================================================================
+
+[BITS 16]
+[ORG 0x8000]
+
+start:
+    mov si, 0x7F00
+    cmp byte [si], 0
+    jne .has_param
+
+    mov ah, 0x01
+    mov si, usage_msg
+    int 0x21
+    ret
+
+.has_param:
+    ; Load the file to 0x3000:0x0000 via the PRos FS API.
+    mov ah, 0x0D
+    mov cx, 0
+    mov dx, 0x3000
+    int 0x22
+    jnc .loaded
+
+    mov ah, 0x04
+    mov si, err_msg
+    int 0x21
+    ret
+
+.loaded:
+    ; DX:AX = file size
+    mov word [data_size], ax
+    mov word [data_size+2], dx
+
+    mov ah, 0x01
+    mov si, header_msg
+    int 0x21
+
+    mov word [data_offset], 0
+
+.dump_loop:
+    mov ax, [data_offset]
+    cmp ax, [data_size]
+    jae .done
+
+    ; print the offset as 4 hex digits
+    mov ax, [data_offset]
+    call print_hex4
+    mov ah, 0x0E
+    mov al, ':'
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    mov al, ' '
+    int 0x10
+
+    ; how many bytes in this row (16 or fewer at the end)
+    mov ax, [data_size]
+    sub ax, [data_offset]
+    cmp ax, 16
+    jae .full_row
+    mov cx, ax
+    jmp .row_len_ok
+.full_row:
+    mov cx, 16
+.row_len_ok:
+
+    push es
+    mov ax, 0x3000
+    mov es, ax
+    mov si, [data_offset]
+.byte_loop:
+    mov al, [es:si]
+    call print_hex2
+    mov ah, 0x0E
+    mov al, ' '
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    inc si
+    loop .byte_loop
+    pop es
+
+    mov ah, 0x0E
+    mov al, 0x0D
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    mov al, 0x0A
+    int 0x10
+
+    add word [data_offset], 16
+    jmp .dump_loop
+
+.done:
+    mov ah, 0x01
+    mov si, done_msg
+    int 0x21
+    ret
+
+; ------------------------------------------------------------------
+; PRINT_HEX2 - print AL as two hex digits.
+; ------------------------------------------------------------------
+print_hex2:
+    push ax
+    push bx
+    mov bl, al
+    shr al, 4
+    call .nibble
+    mov al, bl
+    and al, 0x0F
+    call .nibble
+    pop bx
+    pop ax
+    ret
+.nibble:
+    add al, '0'
+    cmp al, '9'
+    jbe .out
+    add al, 7
+.out:
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    ret
+
+; ------------------------------------------------------------------
+; PRINT_HEX4 - print AX as four hex digits.
+; ------------------------------------------------------------------
+print_hex4:
+    push ax
+    push bx
+    mov bx, ax
+    mov al, bh
+    shr al, 4
+    call print_hex2.nibble
+    mov al, bh
+    and al, 0x0F
+    call print_hex2.nibble
+    mov al, bl
+    shr al, 4
+    call print_hex2.nibble
+    mov al, bl
+    and al, 0x0F
+    call print_hex2.nibble
+    pop bx
+    pop ax
+    ret
+
+; ---- data ----
+usage_msg  db 'Usage: DUMP <filename>', 13, 10, 0
+err_msg    db 'Error: cannot load file', 13, 10, 0
+header_msg db 'Offset  Bytes', 13, 10, 0
+done_msg   db 13, 10, 0
+
+data_size  dd 0
+data_offset dw 0

--- a/programs/ed.asm
+++ b/programs/ed.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 [BITS 16]
 [ORG 0x8000]
 
@@ -253,4 +254,261 @@ convert_to_string:
 ; === includes ===
     %include "programs/ed-common.inc"
     %include "programs/ed-commands.inc"
+=======
+[BITS 16]
+[ORG 0x8000]
+
+start:
+    ; mov byte [buf], 0
+    mov byte [cur_file_name], 0
+    mov byte [file_text_buffer], 0
+    mov byte [command_buffer], 0
+
+    ; cx - counter of file name lenght
+    mov cx, 0
+    ; di - pointer to file name buffer
+    mov di, cur_file_name
+get_opening_file_name_loop:
+    mov al, [si]
+    cmp al, 0
+    je open_file
+    cmp al, 0x20  ; if char = ' ' file name have end
+    je open_file
+    cmp cx, FILE_NAME_MAX_LENGTH
+    jge err_file_name_lenght
+    
+    mov byte [di], al
+    inc si
+    inc cx
+    inc di
+
+    jmp get_opening_file_name_loop
+
+open_file:
+    mov byte [di], 0
+
+    mov si, cur_file_name
+    mov ah, 0x04
+    int 0x22
+    jc err_file_not_be_opened
+    
+    mov di, text_help_command
+    call strcmp
+    cmp ax, 0
+    je put_help_message
+
+    mov si, cur_file_name
+    mov cx, file_text_buffer
+    mov ah, 0x02
+    int 0x22
+
+    mov si, file_text_buffer
+    call strlen
+
+    ; === put successfully message ===
+        mov ah, 0x01
+        mov si, text_file_readed1
+        int 0x21
+        
+        mov ax, cx
+        mov di, number_convert_buffer
+        call convert_to_string
+        mov si, number_convert_buffer
+        mov ah, 0x01
+        int 0x21
+
+        mov si, text_file_readed2
+        int 0x21
+    ; ================================
+
+    mov si, file_text_buffer
+get_line_end_type_loop:
+    cmp byte [si], 0x0A
+    je .mb_lf
+    cmp byte [si], 0x0D
+    je .mb_cr
+    inc si
+    jmp get_line_end_type_loop
+
+.mb_lf:
+    cmp byte [si + 1], 0x0D
+    je .is_crlf
+    jmp .is_lf
+
+.mb_cr:
+    cmp byte [si + 1], 0x0A
+    je .is_crlf
+    mov si, err_text_invalid_end_of_line
+    mov ah, 0x01
+    int 0x21
+
+.is_crlf:
+    or byte [flags], 0b10
+    jmp .end
+.is_lf:
+    and byte [flags], 0b11111101
+
+.end:
+    call save_buffer_for_undo
+    call split_text_by_lines
+
+command_loop:
+    mov cx, 0
+    mov di, command_buffer
+    mov dh, 0x0E
+get_command_char:
+    mov ah, 0
+    int 0x16
+    xchg ah, dh
+    mov bx, 0x0F
+    int 0x10
+    xchg ah, dh
+
+    cmp ah, 0x0E
+    je get_command_bs_handle
+    cmp ah, 0x1C
+    je parse_command
+
+    mov [di], al
+    inc di
+    inc cx
+    jmp get_command_char
+
+get_command_bs_handle:
+    mov ah, 0x0E
+    mov al, 0x20
+    int 0x10
+    mov al, 0x08
+    int 0x10
+
+    cmp cx, 0
+    jne .bs_handle_del_from_buf
+    jmp get_command_char
+.bs_handle_del_from_buf:
+    dec di
+    dec cx
+    jmp get_command_char
+
+parse_command:
+    mov byte [di], 0
+
+    mov ah, 0x0E
+    mov bx, 0
+    mov al, 0x0A
+    int 0x10
+
+    mov al, 0x0D
+    int 0x10
+
+    mov si, command_buffer
+    mov ax, [si]
+    inc si
+
+    cmp al, 0
+    je command_loop
+    cmp al, 'q'
+    je command_q
+    cmp al, 'Q'
+    je exit_prog
+    cmp al, 'p'
+    je command_p
+    cmp al, 'w'
+    je command_w
+    cmp al, 'd'
+    je command_d
+    cmp al, 'u'
+    je command_u
+    cmp al, 'a'
+    je command_a
+    cmp al, 'A'
+    je command_A
+
+    jmp err_unknown_command
+
+exit_prog:
+    ret
+
+err_unknown_command:
+    mov si, err_text_unknown_command
+    mov ah, 0x01
+    int 0x21
+    jmp command_loop
+
+err_file_name_lenght:
+    mov si, err_text_file_name_lenght
+    mov ah, 0x01
+    int 0x21
+    jmp command_loop
+
+err_file_not_be_opened:
+    mov si, err_text_file_not_be_opened
+    mov ah, 0x01
+    int 0x21
+    ret
+
+put_help_message:
+    mov si, text_help_message
+    mov ah, 0x01
+    int 0x21
+    ret
+
+
+; Convert String to Number
+; di - buffer
+; bx - to save
+convert_to_number:
+    mov si, di
+    xor ax, ax
+    xor cx, cx
+.convert_loop:
+    lodsb
+    cmp al, 0         
+    je .done_convert
+    sub al, '0'       
+    imul cx, 10       
+    add cx, ax        
+    jmp .convert_loop
+.done_convert:
+    mov [bx], cx  
+    ret
+
+
+; Number To String
+; ax - number
+; di - buffer [6 bytes]
+convert_to_string:
+    mov si, di          
+    test ax, ax         
+    jnz .non_zero       
+    mov byte [di], '0'  
+    inc di              
+    jmp .terminate      
+
+.non_zero:
+    mov bx, 10          
+    xor cx, cx          
+
+.extract_digits:
+    xor dx, dx          
+    div bx              
+    add dl, '0'         
+    push dx             
+    inc cx              
+    test ax, ax         
+    jnz .extract_digits 
+
+.reverse_digits:
+    pop dx              
+    mov [di], dl        
+    inc di              
+    loop .reverse_digits
+
+.terminate:
+    mov byte [di], 0              
+    ret
+
+; === includes ===
+    %include "programs/ed-common.inc"
+    %include "programs/ed-commands.inc"
+>>>>>>> 88a7da6 (Первый коммит)
 ; ================

--- a/programs/fetch.asm
+++ b/programs/fetch.asm
@@ -9,7 +9,10 @@
 [ORG 0x8000]
 
 start:
+<<<<<<< HEAD
 start:
+=======
+>>>>>>> 88a7da6 (Первый коммит)
     ; ------ Read USER config file to get user name ------
 
     ; Save current directory

--- a/programs/flappy.asm
+++ b/programs/flappy.asm
@@ -1,0 +1,366 @@
+; ==================================================================
+; x16-PRos -- FLAPPY BIRD
+; Flappy Bird clone for 16-bit retro system
+;
+; Made by PRoX-dev
+; ==================================================================
+
+[BITS 16]
+[ORG 0x8000]
+
+%define SCREEN_WIDTH  80
+%define SCREEN_HEIGHT 25
+%define GRAVITY       1
+%define FLAP_POWER    3
+%define PIPE_WIDTH    2
+%define PIPE_GAP      7
+%define PIPE_SPEED    1
+%define MAX_PIPES     3
+
+start:
+    pusha
+    
+    ; Initialize video mode
+    mov ax, 0x03
+    int 0x10
+    
+    ; Hide cursor
+    mov ah, 0x01
+    mov cx, 0x2607
+    int 0x10
+    
+    ; Initialize game state
+    mov byte [bird_y], (SCREEN_HEIGHT / 2)
+    mov byte [bird_vel], 0
+    mov byte [score], 0
+    mov byte [game_over], 0
+    mov byte [pipe_count], 0
+    
+    ; Initialize pipes
+    mov cx, MAX_PIPES
+    mov di, pipes_data
+.init_pipes:
+    mov ax, SCREEN_WIDTH
+    sub ax, 10
+    mov bx, cx
+    imul bx, 25
+    add ax, bx
+    mov [di], al
+    inc di
+    mov al, (SCREEN_HEIGHT / 2)
+    sub al, (PIPE_GAP / 2)
+    mov [di], al
+    inc di
+    loop .init_pipes
+    
+.game_loop:
+    ; Clear screen
+    mov ah, 0x06
+    mov al, 0x00
+    mov bh, 0x0F
+    mov cx, 0x0000
+    mov dx, 0x184F
+    int 0x10
+    
+    ; Draw UI
+    call draw_score
+    call draw_bird
+    call draw_all_pipes
+    call draw_ground
+    
+    ; Handle input
+    call handle_input
+    
+    ; Update game state
+    call update_physics
+    call update_pipes
+    call check_collisions
+    
+    ; Check game over
+    cmp byte [game_over], 1
+    je .game_over_screen
+    
+    ; Delay for frame rate
+    mov ah, 0x86
+    mov cx, 0x0000
+    mov dx, 0x186A  ; ~60 FPS
+    int 0x15
+    
+    jmp .game_loop
+    
+.game_over_screen:
+    ; Draw game over text
+    mov dx, 0x0C28  ; Row 12, Col 40
+    call move_cursor
+    mov si, msg_game_over
+    call print_string
+    
+    mov dx, 0x0E28
+    call move_cursor
+    mov si, msg_score_text
+    call print_string
+    
+    mov dx, 0x1028
+    call move_cursor
+    mov si, msg_restart
+    call print_string
+    
+.wait_key:
+    mov ah, 0x00
+    int 0x16
+    cmp al, 'n'
+    je start
+    cmp al, 'N'
+    je start
+    cmp al, 27
+    je exit
+    jmp .wait_key
+
+; ==================================================================
+; SUBROUTINES
+; ==================================================================
+
+draw_bird:
+    mov dh, [bird_y]
+    mov dl, 10
+    call move_cursor
+    mov al, 0x02  ; Smiley face
+    call write_char
+    ret
+
+draw_all_pipes:
+    mov cx, MAX_PIPES
+    mov si, pipes_data
+.draw_loop:
+    push cx
+    mov dl, [si]
+    mov dh, 0
+    call move_cursor
+    mov dh, [si+1]
+    call draw_single_pipe
+    add si, 2
+    pop cx
+    loop .draw_loop
+    ret
+
+draw_single_pipe:
+    push dx
+    push cx
+    
+    ; Draw top pipe
+    mov ch, 0
+.top_loop:
+    cmp ch, dh
+    jae .draw_gap_pipe
+    mov al, 0xDB
+    call write_char
+    inc ch
+    jmp .top_loop
+    
+.draw_gap_pipe:
+    ; Draw gap
+    mov cx, PIPE_GAP
+.gap_loop_pipe:
+    mov al, ' '
+    call write_char
+    loop .gap_loop_pipe
+    
+    ; Draw bottom pipe
+    mov ch, dh
+    add ch, PIPE_GAP
+.bottom_loop:
+    cmp ch, SCREEN_HEIGHT - 1
+    ja .done_pipe
+    mov al, 0xDB
+    call write_cursor_next
+    inc ch
+    jmp .bottom_loop
+    
+.done_pipe:
+    pop cx
+    pop dx
+    ret
+
+draw_ground:
+    mov dh, SCREEN_HEIGHT - 1
+    mov dl, 0
+    call move_cursor
+    mov cx, SCREEN_WIDTH
+.ground_loop:
+    mov al, 0xDC  ; Ground character
+    call write_char
+    loop .ground_loop
+    ret
+
+draw_score:
+    mov dx, 0x0000
+    call move_cursor
+    mov si, msg_score_prefix
+    call print_string
+    
+    mov al, [score]
+    add al, '0'
+    mov ah, 0x0E
+    mov bh, 0x00
+    int 0x10
+    ret
+
+handle_input:
+    mov ah, 0x01
+    int 0x16
+    jz .no_key
+    
+    mov ah, 0x00
+    int 0x16
+    
+    cmp al, ' '
+    je .flap
+    cmp al, 27
+    je exit
+    
+.no_key:
+    ret
+    
+.flap:
+    mov byte [bird_vel], -FLAP_POWER
+    ret
+
+update_physics:
+    ; Apply gravity
+    mov al, [bird_vel]
+    add al, GRAVITY
+    mov [bird_vel], al
+    
+    ; Update bird position
+    mov al, [bird_y]
+    add al, [bird_vel]
+    mov [bird_y], al
+    
+    ret
+
+update_pipes:
+    mov cx, MAX_PIPES
+    mov si, pipes_data
+.update_loop:
+    mov al, [si]
+    sub al, PIPE_SPEED
+    mov [si], al
+    
+    ; Check if pipe passed bird
+    cmp byte [si], 8
+    jne .no_score
+    inc byte [score]
+    
+.no_score:
+    ; Respawn pipe if off screen
+    cmp byte [si], 0
+    jg .next_pipe
+    mov byte [si], SCREEN_WIDTH - 1
+    
+    ; Randomize gap position
+    xor ax, ax
+    int 0x1A
+    mov ax, dx
+    xor dx, dx
+    mov bx, (SCREEN_HEIGHT - PIPE_GAP - 4)
+    div bx
+    add dl, 2
+    mov [si+1], dl
+    
+.next_pipe:
+    add si, 2
+    loop .update_loop
+    ret
+
+check_collisions:
+    ; Check ground collision
+    mov al, [bird_y]
+    cmp al, SCREEN_HEIGHT - 2
+    jae .collision
+    
+    ; Check ceiling
+    cmp al, 0
+    jle .collision
+    
+    ; Check pipe collision
+    mov cx, MAX_PIPES
+    mov si, pipes_data
+.check_loop:
+    mov al, [bird_x]
+    mov ah, [si]
+    cmp al, ah
+    jne .next_check
+    
+    ; Bird is at pipe X, check Y
+    mov al, [bird_y]
+    mov ah, [si+1]
+    cmp al, ah
+    jb .collision
+    add ah, PIPE_GAP
+    cmp al, ah
+    ja .collision
+    
+.next_check:
+    add si, 2
+    loop .check_loop
+    
+.no_collision:
+    ret
+    
+.collision:
+    mov byte [game_over], 1
+    ret
+
+move_cursor:
+    mov ah, 0x02
+    mov bh, 0x00
+    int 0x10
+    ret
+
+write_char:
+    mov ah, 0x0E
+    mov bh, 0x00
+    int 0x10
+    ret
+
+write_cursor_next:
+    push dx
+    inc dl
+    call move_cursor
+    pop dx
+    jmp write_char
+
+print_string:
+    pusha
+.loop:
+    lodsb
+    or al, al
+    jz .done
+    mov ah, 0x0E
+    mov bh, 0x00
+    int 0x10
+    jmp .loop
+.done:
+    popa
+    ret
+
+exit:
+    popa
+    ret
+
+; ==================================================================
+; DATA
+; ==================================================================
+
+bird_y:          db (SCREEN_HEIGHT / 2)
+bird_vel:        db 0
+bird_x:          db 10
+pipe_count:      db 0
+pipes_data:      times MAX_PIPES * 2 db 0
+score:           db 0
+game_over:       db 0
+
+msg_score_prefix: db "Score: ", 0
+msg_game_over:    db "GAME OVER", 0
+msg_score_text:   db "Score: ", 0
+msg_restart:      db "Press N for new game, ESC to quit", 0

--- a/programs/imfplay.asm
+++ b/programs/imfplay.asm
@@ -29,8 +29,13 @@ start:
 
 		mov ah, 0x10
         mov si, [filename_ptr]
+<<<<<<< HEAD
         mov cx, 43008
         mov dx, 0x2000
+=======
+        mov cx, 0
+        mov dx, 0x3000
+>>>>>>> 88a7da6 (Первый коммит)
         int 22h
 
 		mov ah, 0x01
@@ -45,17 +50,30 @@ start:
 		call start_fast_clock
 
 		; imf type-1: first word is the data length
+<<<<<<< HEAD
 		mov ax, 0x2000
 		mov es, ax
 		mov si, 43008
+=======
+		mov ax, 0x3000
+		mov es, ax
+		mov si, 0
+>>>>>>> 88a7da6 (Первый коммит)
 		mov dx, [es:si]
 		mov [music_length], dx
 
 		; if imf is type-1 then index starts at 2
+<<<<<<< HEAD
 		mov ax, 43008
 		add ax, 2
 		mov [curr_off], ax
 		mov ax, 0x2000
+=======
+		mov ax, 0
+		add ax, 2
+		mov [curr_off], ax
+		mov ax, 0x3000
+>>>>>>> 88a7da6 (Первый коммит)
 		mov [curr_seg], ax
 
 		mov word [bytes_read], 0
@@ -108,8 +126,12 @@ start:
 		call stop_fast_clock
 		call reset_all_registers
 
+<<<<<<< HEAD
 		mov ax, 4c00h
 		int 21h
+=======
+		ret                     ; return to the shell (BIN exit)
+>>>>>>> 88a7da6 (Первый коммит)
 
 get_byte:
 		push ds

--- a/programs/memory.asm
+++ b/programs/memory.asm
@@ -189,7 +189,11 @@ move_down:
     ret
 
 exit_program:
+<<<<<<< HEAD
     int 0x19
+=======
+    ret
+>>>>>>> 88a7da6 (Первый коммит)
 
 print_string:
     mov ah, 0x0E

--- a/programs/mine.asm
+++ b/programs/mine.asm
@@ -143,6 +143,11 @@ DetectWin:
   jne .Break
 .Continue:
   loop .Loop
+<<<<<<< HEAD
+=======
+  pop cx
+  pop ax
+>>>>>>> 88a7da6 (Первый коммит)
   jmp GameWin
 .Break:
   pop cx

--- a/programs/pong.asm
+++ b/programs/pong.asm
@@ -311,7 +311,11 @@ bar_vert:
     ret
 
 exit:
+<<<<<<< HEAD
     int 0x19
+=======
+    ret
+>>>>>>> 88a7da6 (Первый коммит)
 
 LEFT_PLAYER_POS:  db ((SCREEN_HEIGHT - PADDLE_SIZE) / 2)
 RIGHT_PLAYER_POS: db ((SCREEN_HEIGHT - PADDLE_SIZE) / 2)

--- a/programs/procentc.asm
+++ b/programs/procentc.asm
@@ -65,7 +65,26 @@ start:
     mov bx, 100
     mul bx
     mov bx, [num2]
+<<<<<<< HEAD
     div bx
+=======
+    test bx, bx
+    jz .div_zero
+    div bx
+    jmp .after_div
+.div_zero:
+    ; Division by zero would fault the machine (#DE). Show an error.
+    mov ah, 0x01
+    mov si, err_zero_msg
+    int 0x21
+    mov ah, 0x05
+    int 0x21
+    mov ah, 0
+    int 0x16
+    popa
+    ret
+.after_div:
+>>>>>>> 88a7da6 (Первый коммит)
 
     mov di, result_str
     call convert_to_string
@@ -192,6 +211,10 @@ input_msg   db 'Number 1: ', 0
 input2_msg  db 'Number 2: ', 0
 result_msg  db 'Result: ', 0
 percent_msg db '%', 0
+<<<<<<< HEAD
+=======
+err_zero_msg db 'Error: division by zero', 13, 10, 0
+>>>>>>> 88a7da6 (Первый коммит)
 help_msg    db 'This programm will calculate how many percent is num 1 out of num 2. If ', 13, 10
             db 'malfunctioning then make sure num 2 is greater than num 1', 13, 10, 0
 when_done   db 'When done press any key', 13, 10, 0

--- a/programs/setup/setup.asm
+++ b/programs/setup/setup.asm
@@ -477,6 +477,11 @@ setup:
     int 0x22
     mov si, tetris_file
     int 0x22
+<<<<<<< HEAD
+=======
+    mov si, flappy_file
+    int 0x22
+>>>>>>> 88a7da6 (Первый коммит)
     mov si, chars_file
     int 0x22
 
@@ -515,6 +520,11 @@ setup:
     int 0x22
     mov si, tetris_file
     int 0x22
+<<<<<<< HEAD
+=======
+    mov si, flappy_file
+    int 0x22
+>>>>>>> 88a7da6 (Первый коммит)
     mov si, theme_file
     int 0x22
     mov si, calc_file
@@ -836,5 +846,9 @@ space_file         db 'SPACE.BIN', 0
 tetris_file        db 'TETRIS.BIN', 0
 theme_file         db 'THEME.BIN', 0
 writer_file        db 'WRITER.BIN', 0
+<<<<<<< HEAD
+=======
+flappy_file        db 'FLAPPY.BIN', 0
+>>>>>>> 88a7da6 (Первый коммит)
 
 setup_stage_current db 0

--- a/programs/snake.asm
+++ b/programs/snake.asm
@@ -91,12 +91,28 @@ game:
     cmp eax, 3
     jl .delay
     mov [clockticks], ebx
+<<<<<<< HEAD
     in al, 0x60
     
 .direction:
     cmp al, 177     ; 'N' - новая игра
     je start
     cmp al, 0x01    ; ESC - выход
+=======
+    ; Read the keyboard via the BIOS (a raw port read would steal scan
+    ; codes from the BIOS keyboard buffer and corrupt its state).
+    mov ah, 0x01
+    int 0x16
+    jz .delay
+    mov ah, 0x00
+    int 0x16
+    mov al, ah        ; scancode in AL
+    
+.direction:
+    cmp al, 177    ; 'N' - new game
+    je start
+    cmp al, 0x01    ; ESC - exit
+>>>>>>> 88a7da6 (Первый коммит)
     je esc_exit
     and al, 0x7F
     cmp al, 17      ; W
@@ -195,11 +211,19 @@ game:
     call print
 .fail_wait:
     in al, 0x60
+<<<<<<< HEAD
     cmp al, 177     ; 'N' - новая игра
     jne .check_esc_fail
     jmp start
 .check_esc_fail:
     cmp al, 0x01    ; ESC - выход
+=======
+    cmp al, 177    ; 'N' - new game
+    jne .check_esc_fail
+    jmp start
+.check_esc_fail:
+    cmp al, 0x01    ; ESC - exit
+>>>>>>> 88a7da6 (Первый коммит)
     jne .fail_wait
     jmp esc_exit
 
@@ -248,7 +272,11 @@ print:
     ret
     
 esc_exit:
+<<<<<<< HEAD
     int 0x19
+=======
+    ret
+>>>>>>> 88a7da6 (Первый коммит)
     
 msg_name: db 'Snake game',0
 msg_controls: db 'WASD - direction N - new Game ESC - quit',0

--- a/programs/tbasic.asm
+++ b/programs/tbasic.asm
@@ -43,7 +43,13 @@ START:
 		call	ILM_NLINE				;new line
 
 CO:
+<<<<<<< HEAD
 		mov		sp,STACK_OFF			;clear SP (error could happened)
+=======
+		mov		ax,STACK_SEG			;set a safe stack segment for the
+		mov		ss,ax					;interpreter (never leave SS = 0,
+		mov		sp,STACK_OFF			;otherwise deep stacks corrupt the IVT)
+>>>>>>> 88a7da6 (Первый коммит)
 
 		mov		ax,PGM					;copy PGM address
 		mov		[PGP],ax				;set PGP at beginning of program

--- a/programs/tetris.asm
+++ b/programs/tetris.asm
@@ -559,7 +559,18 @@ game_over:
     call set_cursor
     mov si, msg_game_over
     call print_string
+<<<<<<< HEAD
     jmp $
+=======
+    mov dh, 14
+    mov dl, 35
+    call set_cursor
+    mov si, msg_exit_prompt
+    call print_string
+    mov ah, 0
+    int 0x16            ; wait for a key
+    ret                 ; return to the shell (never hang the machine)
+>>>>>>> 88a7da6 (Первый коммит)
 
 ; --- DATA ---
 
@@ -596,6 +607,10 @@ msg_score:     db "SCORE: ", 0
 msg_next:      db "NEXT:", 0
 clr_next:      db "          ", 0 ;
 msg_game_over: db "GAME OVER", 0
+<<<<<<< HEAD
+=======
+msg_exit_prompt: db "Press any key to exit", 0
+>>>>>>> 88a7da6 (Первый коммит)
 frame_left:    db "<|", 0
 frame_right:   db "|>", 0
 footer_start:  db "  ", 0

--- a/programs/uptime.asm
+++ b/programs/uptime.asm
@@ -1,0 +1,114 @@
+; ==================================================================
+; x16-PRos - UPTIME.BIN. Shows the time elapsed since midnight
+; (from the BIOS tick counter) as HH:MM:SS.
+; ==================================================================
+
+[BITS 16]
+[ORG 0x8000]
+
+start:
+    mov ah, 0x00
+    int 0x1A            ; CX:DX = ticks since midnight (~18.2065 ticks/sec)
+
+    ; ticks -> seconds = ticks / 18
+    mov ax, dx
+    mov dx, cx          ; DX:AX = ticks
+    mov bx, 18
+    call div32_16       ; DX:AX = seconds, CX = remainder
+    mov [data_seconds], ax
+    mov [data_seconds+2], dx
+
+    ; hours = seconds / 3600
+    mov dx, [data_seconds+2]
+    mov ax, [data_seconds]
+    mov bx, 3600
+    call div32_16       ; DX:AX = hours, CX = remainder (seconds within the hour)
+    mov [data_hours], ax
+    mov [data_remainder], cx
+
+    ; minutes = remainder / 60
+    mov ax, [data_remainder]
+    xor dx, dx
+    mov bx, 60
+    div bx              ; AX = minutes, DX = seconds
+    mov [data_minutes], ax
+    mov [data_secs], dx
+
+    ; print HH:MM:SS
+    mov ax, [data_hours]
+    call print2
+    mov al, ':'
+    call print_char
+    mov ax, [data_minutes]
+    call print2
+    mov al, ':'
+    call print_char
+    mov ax, [data_secs]
+    call print2
+    mov ah, 0x0E
+    mov al, 0x0D
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    mov al, 0x0A
+    int 0x10
+    ret
+
+; ------------------------------------------------------------------
+; DIV32_16 - 32-bit / 16-bit divide.
+; IN : DX:AX = dividend, BX = divisor (1..0xFFFF)
+; OUT: DX:AX = quotient, CX = remainder
+; ------------------------------------------------------------------
+div32_16:
+    push si
+    mov si, ax          ; SI = low word
+    mov ax, dx          ; AX = high word
+    xor dx, dx
+    div bx              ; AX = high/BX, DX = high%BX
+    mov cx, ax          ; CX = high quotient
+    mov ax, si          ; AX = low word
+    div bx              ; AX = low quotient, DX = remainder
+    mov si, cx
+    mov cx, dx
+    mov dx, si
+    pop si
+    ret
+
+; ------------------------------------------------------------------
+; PRINT2 - print AX (0-99) as two digits with a leading zero.
+; ------------------------------------------------------------------
+print2:
+    push ax
+    push dx
+    xor dx, dx
+    mov bx, 10
+    div bx              ; AL = tens, DL = ones
+    add al, '0'
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    mov al, dl
+    add al, '0'
+    int 0x10
+    pop dx
+    pop ax
+    ret
+
+; ------------------------------------------------------------------
+; PRINT_CHAR - print AL as a character.
+; ------------------------------------------------------------------
+print_char:
+    push ax
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x0F
+    int 0x10
+    pop ax
+    ret
+
+data_seconds   dd 0
+data_hours     dw 0
+data_remainder dw 0
+data_minutes   dw 0
+data_secs      dw 0

--- a/programs/write.asm
+++ b/programs/write.asm
@@ -1193,4 +1193,8 @@ modified        db 0
 had_crlf        db 0
 
 filename        times 16 db 0
+<<<<<<< HEAD
 status_msg      times 30 db 0
+=======
+status_msg      times 30 db 0
+>>>>>>> 88a7da6 (Первый коммит)

--- a/src/kernel/features/api/api_fs.asm
+++ b/src/kernel/features/api/api_fs.asm
@@ -312,6 +312,10 @@ int22_handler:
 ; ==================================================================
 copy_caller_string_si:
     push ax
+<<<<<<< HEAD
+=======
+    push cx
+>>>>>>> 88a7da6 (Первый коммит)
     push di
     push es
     push ds
@@ -322,15 +326,31 @@ copy_caller_string_si:
 
     mov ax, [cs:caller_ds_save_22]
     mov ds, ax
+<<<<<<< HEAD
+=======
+    mov cx, 63
+>>>>>>> 88a7da6 (Первый коммит)
 .cl:
     lodsb
     stosb
     test al, al
+<<<<<<< HEAD
     jnz .cl
 
     pop ds
     pop es
     pop di
+=======
+    jz .cl_done
+    loop .cl
+    xor al, al
+    stosb
+.cl_done:
+    pop ds
+    pop es
+    pop di
+    pop cx
+>>>>>>> 88a7da6 (Первый коммит)
     pop ax
     mov si, .si_scratch
     ret
@@ -344,6 +364,10 @@ copy_caller_string_si:
 ; ==================================================================
 copy_caller_string_di:
     push ax
+<<<<<<< HEAD
+=======
+    push cx
+>>>>>>> 88a7da6 (Первый коммит)
     push si
     push es
     push ds
@@ -356,15 +380,31 @@ copy_caller_string_di:
 
     mov ax, [cs:caller_ds_save_22]
     mov ds, ax
+<<<<<<< HEAD
+=======
+    mov cx, 63
+>>>>>>> 88a7da6 (Первый коммит)
 .cl:
     lodsb
     stosb
     test al, al
+<<<<<<< HEAD
     jnz .cl
 
     pop ds
     pop es
     pop si
+=======
+    jz .cl_done
+    loop .cl
+    xor al, al
+    stosb
+.cl_done:
+    pop ds
+    pop es
+    pop si
+    pop cx
+>>>>>>> 88a7da6 (Первый коммит)
     pop ax
     mov di, .di_scratch
     ret

--- a/src/kernel/features/api/api_output.asm
+++ b/src/kernel/features/api/api_output.asm
@@ -16,7 +16,11 @@
 ;   0x09: CP866 control (AL=0x00 disable, AL=0x01 default font, AL=0x02 by name SI)
 ;   0x0A: Get system time (OUT: CH=hour, CL=min, DH=sec)
 ;   0x0B: Get system date (OUT: CH=century, CL=year, DH=month, DL=day)
+<<<<<<< HEAD
 ;   0x0С: Clear screen and aply theme from CONF.DIR/THEME.CFG
+=======
+;   0x0C: Clear screen and aply theme from CONF.DIR/THEME.CFG
+>>>>>>> 88a7da6 (Первый коммит)
 ; Preserves all registers unless specified
 ; ==================================================================
 
@@ -184,6 +188,10 @@ int21_handler:
 ; ========================================================================
 copy_caller_string_si_21:
     push ax
+<<<<<<< HEAD
+=======
+    push cx
+>>>>>>> 88a7da6 (Первый коммит)
     push di
     push es
     push ds
@@ -194,15 +202,31 @@ copy_caller_string_si_21:
 
     mov ax, [cs:caller_ds_save_21]
     mov ds, ax
+<<<<<<< HEAD
+=======
+    mov cx, 63
+>>>>>>> 88a7da6 (Первый коммит)
 .cl:
     lodsb
     stosb
     test al, al
+<<<<<<< HEAD
     jnz .cl
 
     pop ds
     pop es
     pop di
+=======
+    jz .cl_done
+    loop .cl
+    xor al, al
+    stosb
+.cl_done:
+    pop ds
+    pop es
+    pop di
+    pop cx
+>>>>>>> 88a7da6 (Первый коммит)
     pop ax
     mov si, .scratch
     ret

--- a/src/kernel/features/com/0Fh.asm
+++ b/src/kernel/features/com/0Fh.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_0Fh:
     call fcb_to_path_buffer
 
@@ -57,3 +58,64 @@ com_0Fh:
     stc
 
     iret
+=======
+com_0Fh:
+    call fcb_to_path_buffer
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x04
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jc .fail
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x08
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jc .fail
+
+    push ds
+    pop es
+
+    mov di, dx
+    mov [es:di+0x10], bx
+    mov word [es:di+0x12], 0
+
+    mov ah, 0x04
+    int 0x1A
+    call bcd_to_bin_date
+    call date_to_dos
+    mov [es:di+0x14], ax
+
+    mov ah, 0x02
+    int 0x1A
+    call bcd_to_bin_time
+    call time_to_dos
+    mov [es:di+0x16], ax
+
+    mov word [es:di+0x0E], 128
+    mov word [es:di+0x0C], 0
+    mov byte [es:di+0x20], 0
+
+    xor al, al
+    clc
+    iret
+
+.fail:
+    mov al, 0xFF
+    stc
+
+    iret
+>>>>>>> 88a7da6 (Первый коммит)

--- a/src/kernel/features/com/10h.asm
+++ b/src/kernel/features/com/10h.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_10h:
     call fcb_to_path_buffer
 
@@ -37,4 +38,45 @@ com_10h:
     mov al, 0xFF
     stc
 
+=======
+com_10h:
+    call fcb_to_path_buffer
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x04
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jc .fail
+
+    push ds
+    pop es
+    mov di, dx
+
+    mov ah, 0x04
+    int 0x1A
+    call bcd_to_bin_date
+    call date_to_dos
+    mov [es:di+0x14], ax
+
+    mov ah, 0x02
+    int 0x1A
+    call bcd_to_bin_time
+    call time_to_dos
+    mov [es:di+0x16], ax
+
+    xor al, al
+    clc
+    iret
+
+.fail:
+    mov al, 0xFF
+    stc
+
+>>>>>>> 88a7da6 (Первый коммит)
     iret

--- a/src/kernel/features/com/13h.asm
+++ b/src/kernel/features/com/13h.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_13h:
     call fcb_to_path_buffer
 
@@ -21,4 +22,29 @@ com_13h:
     mov al, 0xFF
     stc
 
+=======
+com_13h:
+    call fcb_to_path_buffer
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x06
+    int 0x22
+
+    pop ds
+    pop dx
+    
+    jc .fail
+
+    xor al, al
+    clc
+    iret
+
+.fail:
+    mov al, 0xFF
+    stc
+
+>>>>>>> 88a7da6 (Первый коммит)
     iret

--- a/src/kernel/features/com/16h.asm
+++ b/src/kernel/features/com/16h.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_16h:
     call fcb_to_path_buffer
 
@@ -73,4 +74,81 @@ com_16h:
     mov al, 0xFF
     stc
 
+=======
+com_16h:
+    call fcb_to_path_buffer
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x04
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jnc .delete_existing
+
+.create:
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x05
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jc .fail
+    jmp .fill_fcb
+
+.delete_existing:
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov ah, 0x06
+    int 0x22
+
+    pop ds
+    pop dx
+
+    jmp .create
+
+.fill_fcb:
+    push ds
+    pop es
+
+    mov di, dx
+
+    mov word [es:di+0x10], 0
+    mov word [es:di+0x12], 0
+
+    mov ah, 0x04
+    int 0x1A
+    call bcd_to_bin_date
+    call date_to_dos
+    mov [es:di+0x14], ax
+
+    mov ah, 0x02
+    int 0x1A
+    call bcd_to_bin_time
+    call time_to_dos
+    mov [es:di+0x16], ax
+
+    mov word [es:di+0x0E], 128
+    mov word [es:di+0x0C], 0
+    mov byte [es:di+0x20], 0
+
+    xor al, al
+    clc
+    iret
+
+.fail:
+    mov al, 0xFF
+    stc
+
+>>>>>>> 88a7da6 (Первый коммит)
     iret

--- a/src/kernel/features/com/17h.asm
+++ b/src/kernel/features/com/17h.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_17h:
     call fcb_to_path_buffer
 
@@ -43,4 +44,51 @@ com_17h:
     mov al, 0xFF
     stc
 
+=======
+com_17h:
+    call fcb_to_path_buffer
+
+    push dx
+    push ds
+
+    mov si, com_path_buffer
+    mov cx, 0x3000
+    mov ah, 0x02
+    int 0x22
+    jc .fail
+
+    push bx
+
+    mov si, com_path_buffer
+    mov ah, 0x06
+    int 0x22
+
+    pop cx
+    jc .fail
+
+    mov si, dx
+    add si, 16
+    call fcb_str_to_normal
+
+    mov si, com_path_buffer2
+    mov bx, 0x3000
+    mov ah, 0x03
+    int 0x22
+    jc .fail
+
+    pop ds
+    pop dx
+
+    xor al, al
+    clc
+    
+    iret
+
+.fail:
+    pop ds
+    pop dx
+    mov al, 0xFF
+    stc
+
+>>>>>>> 88a7da6 (Первый коммит)
     iret

--- a/src/kernel/features/com/2Ah.asm
+++ b/src/kernel/features/com/2Ah.asm
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 com_2Ah:
     push bx
     push ax
@@ -19,3 +20,126 @@ com_2Ah:
     pop ax
     pop bx
     iret
+=======
+; ==================================================================
+; AH=2Ah - Get system date (DOS-compatible).
+; OUT: CX = year (e.g., 2026), DH = month, DL = day, AL = day of week
+;      (0 = Sunday .. 6 = Saturday)
+; ==================================================================
+com_2Ah:
+    push bx
+    push cx
+    push dx
+
+    mov ah, 0x04
+    int 0x1A            ; CH=century(BCD), CL=year(BCD), DH=month, DL=day
+
+    mov al, cl
+    call bcd_to_bin
+    mov cl, al          ; CL = year (0-99)
+    mov al, ch
+    call bcd_to_bin
+    mov ch, al          ; CH = century (e.g., 20)
+    mov al, dh
+    call bcd_to_bin
+    mov dh, al          ; DH = month
+    mov al, dl
+    call bcd_to_bin
+    mov dl, al          ; DL = day
+
+    ; Full year = century*100 + year -> CX
+    mov al, ch
+    mov bl, 100
+    mul bl              ; AX = century*100
+    mov [.year_hi], ax
+    mov al, cl
+    xor ah, ah          ; AX = year
+    add ax, [.year_hi]  ; AX = full year
+    mov cx, ax
+
+    ; Day of week (Zeller/Sakamoto), DOS: 0 = Sunday.
+    ; AL = (h + 1) mod 7, h = (day + 13(m+1)/5 + K + K/4 + J/4 + 5J) mod 7
+    push ax
+    push cx
+    push dx
+    mov bx, ax          ; BX = full year
+    xor dx, dx
+    mov cx, 100
+    mov ax, bx
+    div cx              ; AX = J, DX = K
+    mov [.j], ax
+    mov [.k], dx
+    pop dx
+    pop cx
+    pop ax
+
+    cmp dh, 3
+    jge .no_adj
+    add dh, 12
+    dec ax
+.no_adj:
+
+    ; sum = q(day) + 13(m+1)/5 + K/4 + K + J/4 + 5J
+    mov bx, ax          ; BX = adjusted year
+    mov ax, bx
+    xor dx, dx
+    mov cx, 100
+    div cx              ; AX = J2, DX = K2
+    mov [.j2], ax
+    mov [.k2], dx
+
+    mov [.sum], dx      ; start with K2
+    mov ax, [.j2]
+    shr ax, 1
+    shr ax, 1
+    add [.sum], ax      ; + J2/4
+    mov ax, [.j2]
+    mov cx, 5
+    mul cx
+    add [.sum], ax      ; + 5*J2
+
+    mov al, dh          ; m (adjusted month)
+    inc al
+    mov bl, 13
+    mul bl
+    mov bl, 5
+    div bl              ; AL = 13(m+1)/5
+    xor ah, ah
+    add [.sum], ax
+
+    mov ax, [.k2]
+    shr ax, 2
+    add [.sum], ax      ; + K2/4
+    mov ax, [.k2]
+    add [.sum], ax      ; + K2
+    xor bx, bx
+    mov bl, dl          ; q = day
+    add [.sum], bx
+
+    mov ax, [.sum]
+    xor dx, dx
+    mov cx, 7
+    div cx              ; DX = h (0 = Saturday)
+    inc dx              ; h+1
+    mov ax, dx
+    xor dx, dx
+    mov cx, 7
+    div cx
+    mov al, dl          ; AL = day of week (0 = Sunday)
+
+    mov [.dow], al
+
+    pop dx
+    pop cx
+    pop bx
+    mov al, [.dow]
+    iret
+
+.j dw 0
+.k dw 0
+.j2 dw 0
+.k2 dw 0
+.sum dw 0
+.dow db 0
+.year_hi dw 0
+>>>>>>> 88a7da6 (Первый коммит)

--- a/src/kernel/features/com/com.asm
+++ b/src/kernel/features/com/com.asm
@@ -134,16 +134,30 @@ int20_handler:
     mov ds, ax
     mov es, ax
 
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 0
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov ss, [com_ss_save]
     mov sp, [com_stack_save]
 
     sti
 
+<<<<<<< HEAD
     call api_output_init
 
     mov si, .finished_msg
     mov ah, 0x01
     int 0x21
+=======
+    ; Print the finished message directly instead of via INT 0x21 - the
+    ; DOS vector was just un-hooked by the IVT restore above, so relying
+    ; on the interrupt would depend on which handler the saved table
+    ; points at.
+    mov si, .finished_msg
+    call print_string
+>>>>>>> 88a7da6 (Первый коммит)
 
     ; Wait for key press
     mov ah, 0
@@ -245,6 +259,11 @@ int21_dos_handler:
     je com_2Ah
     cmp ah, 0x2C
     je com_2Ch
+<<<<<<< HEAD
+=======
+    cmp ah, 0x2E
+    je com_2Eh
+>>>>>>> 88a7da6 (Первый коммит)
     cmp ah, 0x2F
     je com_2Fh
     cmp ah, 0x30
@@ -259,14 +278,38 @@ int21_dos_handler:
     je com_3Ah
     cmp ah, 0x3B
     je com_3Bh
+<<<<<<< HEAD
     cmp ah, 0x41
     je com_41h
+=======
+    cmp ah, 0x3C
+    je com_3Ch
+    cmp ah, 0x3D
+    je com_3Dh
+    cmp ah, 0x3E
+    je com_3Eh
+    cmp ah, 0x3F
+    je com_3Fh
+    cmp ah, 0x40
+    je com_40h
+    cmp ah, 0x41
+    je com_41h
+    cmp ah, 0x42
+    je com_42h
+    cmp ah, 0x43
+    je com_43h
+>>>>>>> 88a7da6 (Первый коммит)
     cmp ah, 0x4C
     je com_4Ch
     cmp ah, 0x4D
     je com_4Dh
     cmp ah, 0x54
     je com_54h
+<<<<<<< HEAD
+=======
+    cmp ah, 0x56
+    je com_56h
+>>>>>>> 88a7da6 (Первый коммит)
     iret
 
 
@@ -409,6 +452,10 @@ bcd_to_bin_time:
 %include "src/kernel/features/com/35h.asm"
 %include "src/kernel/features/com/36h.asm"
 %include "src/kernel/features/com/39h.asm"
+<<<<<<< HEAD
+=======
+%include "src/kernel/features/com/handles.asm"
+>>>>>>> 88a7da6 (Первый коммит)
 %include "src/kernel/features/com/3Ah.asm"
 %include "src/kernel/features/com/3Bh.asm"
 %include "src/kernel/features/com/41h.asm"

--- a/src/kernel/features/com/fcb.inc
+++ b/src/kernel/features/com/fcb.inc
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 ; ========================================================================
 ; FCB helper functions for DOS emulation
 ;
@@ -164,3 +165,170 @@ time_to_dos:
     pop dx
     pop cx
     ret
+=======
+; ========================================================================
+; FCB helper functions for DOS emulation
+;
+; Provides utilities to convert FCB structures to normal filenames
+; and format DOS date/time values
+; ========================================================================
+
+; fcb_to_path_buffer: convert FCB at caller DS:DX to ASCIIZ in com_path_buffer
+; IN:  DS:DX = pointer to FCB (caller's segment)
+; OUT: com_path_buffer filled, DS/ES restored
+fcb_to_path_buffer:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    push ds             ; save caller DS
+
+    mov si, dx
+    inc si              ; skip drive byte, SI = filename field
+
+    ; DS = caller segment (for reading FCB)
+    ; ES = 0x2000 (for writing com_path_buffer)
+    mov ax, 0x2000
+    mov es, ax
+    mov di, com_path_buffer
+
+    mov cx, 8
+.copy_name:
+    mov al, [ds:si]     ; read from caller segment
+    inc si
+    cmp al, ' '
+    je .name_done
+    stosb
+    loop .copy_name
+.name_done:
+    add si, cx
+
+    mov al, '.'
+    stosb
+
+    mov cx, 3
+.copy_ext:
+    mov al, [ds:si]     ; read from caller segment
+    inc si
+    cmp al, ' '
+    je .ext_done
+    stosb
+    loop .copy_ext
+.ext_done:
+
+    xor al, al
+    stosb
+
+    pop ds
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; fcb_str_to_normal: convert FCB name at caller DS:SI to ASCIIZ in com_path_buffer2
+; IN:  DS:SI = pointer to 11-byte FCB name (caller's segment)
+; OUT: com_path_buffer2 filled, DS/ES restored
+fcb_str_to_normal:
+    push ax
+    push cx
+    push si
+    push di
+    push es
+    push ds             ; save caller DS
+
+    ; DS = caller segment (for reading)
+    ; ES = 0x2000 (for writing)
+    mov ax, 0x2000
+    mov es, ax
+    mov di, com_path_buffer2
+
+    mov cx, 8
+.copy_name:
+    mov al, [ds:si]     ; read from caller segment
+    inc si
+    cmp al, ' '
+    je .name_done
+    stosb
+    loop .copy_name
+.name_done:
+    add si, cx
+
+    mov al, '.'
+    stosb
+
+    mov cx, 3
+.copy_ext:
+    mov al, [ds:si]     ; read from caller segment
+    inc si
+    cmp al, ' '
+    je .ext_done
+    stosb
+    loop .copy_ext
+.ext_done:
+
+    xor al, al
+    stosb
+
+    pop ds
+    pop es
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; date_to_dos: convert date to DOS packed format
+; IN:  CL = year (0-99), DH = month (1-12), DL = day (1-31)
+; OUT: AX = packed DOS date ((year-1980)<<9 | month<<5 | day)
+date_to_dos:
+    push cx
+    push dx
+
+    xor ah, ah
+    mov al, cl
+    add ax, 20          ; century offset: (year + 2000) - 1980 = year + 20
+    shl ax, 9           ; year in bits 15-9
+
+    xor ch, ch
+    mov cl, dh          ; month
+    shl cx, 5           ; month in bits 8-5
+    or ax, cx
+
+    xor dh, dh          ; day in bits 4-0
+    or ax, dx
+
+    pop dx
+    pop cx
+    ret
+
+; time_to_dos: convert time to DOS packed format
+; IN:  CH = hours (0-23), CL = minutes (0-59), DH = seconds (0-59)
+; OUT: AX = packed DOS time (hours<<11 | minutes<<5 | seconds/2)
+time_to_dos:
+    push cx
+    push dx
+
+    xor ah, ah
+    mov al, ch          ; hours
+    shl ax, 11          ; hours in bits 15-11
+
+    push ax
+    xor ah, ah
+    mov al, cl          ; minutes
+    shl ax, 5           ; minutes in bits 10-5
+    mov cx, ax
+    pop ax
+    or ax, cx
+
+    mov cl, dh          ; seconds
+    shr cl, 1           ; seconds/2 in bits 4-0
+    xor ch, ch
+    or ax, cx
+
+    pop dx
+    pop cx
+    ret
+>>>>>>> 88a7da6 (Первый коммит)

--- a/src/kernel/features/com/handles.asm
+++ b/src/kernel/features/com/handles.asm
@@ -1,0 +1,710 @@
+; ==================================================================
+; x16-PRos - DOS file-handle compatibility functions
+; Copyright (C) 2025 PRoX2011
+;
+; Implements the MS-DOS INT 0x21 file-handle API so DOS programs can
+; create, open, read, write and seek files:
+;   AH=2Eh Set/Reset verify flag
+;   AH=3Ch Create file          AH=3Dh Open file
+;   AH=3Eh Close file           AH=3Fh Read file
+;   AH=40h Write file           AH=42h Seek file
+;   AH=43h Get/set attribute    AH=56h Rename file
+;
+; Handles: up to MAX_HANDLES files, each loaded into a private 16 KiB
+; buffer at HANDLE_BUF_SEG. Reads/writes operate on the in-memory
+; copy; Close writes it back to disk when modified.
+;
+; NOTE: every function pushes exactly 8 registers before exit so the
+; DOS_SET_CF / DOS_CLR_CF macros (which patch the caller's saved
+; flags at [SP+20]) work correctly.
+; ==================================================================
+
+MAX_HANDLES      equ 4
+HANDLE_BUF_SIZE  equ 0x4000
+HANDLE_BUF_SEG   equ 0x4000
+
+; ---- handle table ----
+dos_handle_inuse   times MAX_HANDLES db 0
+dos_handle_size    times MAX_HANDLES dw 0
+dos_handle_pos     times MAX_HANDLES dw 0
+dos_handle_modified times MAX_HANDLES db 0
+dos_handle_name    times MAX_HANDLES*16 db 0
+dos_caller_ds      dw 0
+dos_result         dw 0
+dos_tmp            dw 0
+dos_tmp2           dw 0
+
+; ==================================================================
+; DOS_SET_CF / DOS_CLR_CF - patch the carry flag in the caller's
+; saved flags. Assumes exactly 8 pushes (16 bytes) on the stack.
+; ==================================================================
+%macro dos_set_cf 0
+    mov bp, sp
+    or word [bp + 20], 0x0001
+%endmacro
+%macro dos_clr_cf 0
+    mov bp, sp
+    and word [bp + 20], 0xFFFE
+%endmacro
+
+; ------------------------------------------------------------------
+; DOS_ALLOC_HANDLE - find a free handle slot.
+; OUT: CF=0, BX = handle index; CF=1 if the table is full.
+; ------------------------------------------------------------------
+dos_alloc_handle:
+    push ax
+    mov bx, 0
+.dh_loop:
+    cmp bx, MAX_HANDLES
+    jae .dh_full
+    cmp byte [cs:dos_handle_inuse + bx], 0
+    je .dh_found
+    inc bx
+    jmp .dh_loop
+.dh_full:
+    pop ax
+    stc
+    ret
+.dh_found:
+    pop ax
+    clc
+    ret
+
+; ------------------------------------------------------------------
+; DOS_COPY_NAME - copy NUL-terminated name from DS:SI to ES:DI,
+; bounded to 15 chars + terminator.
+; ------------------------------------------------------------------
+dos_copy_name:
+    push ax
+    push cx
+    push si
+    push di
+    mov cx, 15
+.dn_loop:
+    lodsb
+    stosb
+    test al, al
+    jz .dn_done
+    loop .dn_loop
+    xor al, al
+    stosb
+.dn_done:
+    pop di
+    pop si
+    pop cx
+    pop ax
+    ret
+
+; ------------------------------------------------------------------
+; DOS_COPY_NEW_NAME - copy ASCIIZ from segment AX:offset DI to the
+; kernel buffer com_path_buffer2.
+; ------------------------------------------------------------------
+dos_copy_new_name:
+    push bx
+    push cx
+    push si
+    push di
+    push ds
+    push es
+    mov bx, KERNEL_DATA_SEG
+    mov ds, bx
+    mov es, bx
+    mov si, di
+    mov di, com_path_buffer2
+    mov ds, ax
+    mov cx, 63
+.dcn_loop:
+    lodsb
+    stosb
+    test al, al
+    jz .dcn_done
+    loop .dcn_loop
+    xor al, al
+    stosb
+.dcn_done:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop cx
+    pop bx
+    ret
+
+; ==================================================================
+; AH=2Eh - Set/Reset verify flag. AL = 0 or 1.
+; ==================================================================
+com_2Eh:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    mov [cs:verify_flag], al
+    mov word [cs:dos_result], 0
+    dos_clr_cf
+
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=43h - Get/set file attribute. DS:DX = filename, AL = 0 get / 1 set.
+; Always reports the normal archive attribute.
+; ==================================================================
+com_43h:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    test al, al
+    jnz .h43_set
+    ; get attribute: return 0x20 (archive) in CX
+    mov word [cs:dos_result], 0x20
+    dos_clr_cf
+    jmp .h43_exit
+.h43_set:
+    ; set attribute: accept any value but keep the filesystem entry.
+    mov word [cs:dos_result], cx
+    dos_clr_cf
+.h43_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=56h - Rename file. DS:DX = old name, ES:DI = new name.
+; ==================================================================
+com_56h:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    ; Remember the caller's new-name offset (DI may be clobbered).
+    mov [cs:dos_tmp2], di
+
+    ; old name (DS:DX) -> com_path_buffer
+    mov si, dx
+    call com_copy_path_from_caller
+    mov [cs:dos_tmp], ax
+
+    ; new name (ES:DI) -> com_path_buffer2
+    mov ax, es
+    mov di, [cs:dos_tmp2]
+    call dos_copy_new_name
+
+    ; rename via the filesystem
+    push ds
+    push es
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov ax, [cs:dos_tmp]
+    mov bx, com_path_buffer2
+    call fs_rename_file
+    pop es
+    pop ds
+    jnc .h56_ok
+    mov word [cs:dos_result], 0x0002
+    dos_set_cf
+    jmp .h56_exit
+.h56_ok:
+    mov word [cs:dos_result], 0
+    dos_clr_cf
+.h56_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=3Ch - Create file. DS:DX = filename, CX = attribute.
+; OUT: AX = handle.
+; ==================================================================
+com_3Ch:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    mov si, dx
+    call com_copy_path_from_caller   ; AX = com_path_buffer
+
+    push ds
+    push es
+    mov bx, KERNEL_DATA_SEG
+    mov ds, bx
+    mov es, bx
+    call fs_create_file
+    pop es
+    pop ds
+    jc .h3C_create_error
+
+    call dos_alloc_handle
+    jc .h3C_no_handles
+
+    ; set up the new handle
+    mov si, com_path_buffer
+    mov di, dos_handle_name
+    push ax
+    mov ax, bx
+    shl ax, 4
+    add di, ax
+    pop ax
+    push ds
+    push es
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    call dos_copy_name
+    pop es
+    pop ds
+
+    mov byte [cs:dos_handle_inuse + bx], 1
+    mov ax, bx
+    shl ax, 1
+    mov si, ax
+    mov word [cs:dos_handle_size + si], 0
+    mov word [cs:dos_handle_pos + si], 0
+    mov byte [cs:dos_handle_modified + bx], 0
+
+    mov [cs:dos_result], bx
+    dos_clr_cf
+    jmp .h3C_exit
+
+.h3C_create_error:
+    mov word [cs:dos_result], 0x0003
+    dos_set_cf
+    jmp .h3C_exit
+.h3C_no_handles:
+    mov word [cs:dos_result], 0x0004
+    dos_set_cf
+.h3C_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=3Dh - Open file. DS:DX = filename, AL = access mode.
+; OUT: AX = handle.
+; ==================================================================
+com_3Dh:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    mov si, dx
+    call com_copy_path_from_caller   ; AX = com_path_buffer
+
+    call dos_alloc_handle
+    jc .h3D_no_handles
+
+    ; load the file into the handle buffer
+    mov cx, 0                        ; offset
+    mov dx, bx
+    shl dx, 10
+    add dx, HANDLE_BUF_SEG           ; handle buffer segment
+    push ds
+    push es
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov ax, com_path_buffer
+    call fs_load_huge_file
+    pop es
+    pop ds
+    jc .h3D_load_error
+    ; DX:AX = file size; must fit in the 16 KiB buffer
+    cmp dx, 0
+    jne .h3D_too_big
+    cmp ax, HANDLE_BUF_SIZE
+    ja .h3D_too_big
+
+    ; store the name in the handle slot
+    mov si, com_path_buffer
+    mov di, dos_handle_name
+    push ax
+    mov ax, bx
+    shl ax, 4
+    add di, ax
+    pop ax
+    push ds
+    push es
+    mov bx, KERNEL_DATA_SEG
+    mov ds, bx
+    mov es, bx
+    call dos_copy_name
+    pop es
+    pop ds
+
+    ; populate the handle entry
+    mov byte [cs:dos_handle_inuse + bx], 1
+    push ax
+    mov ax, bx
+    shl ax, 1
+    mov si, ax
+    pop ax
+    mov [cs:dos_handle_size + si], ax
+    mov word [cs:dos_handle_pos + si], 0
+    mov byte [cs:dos_handle_modified + bx], 0
+
+    mov [cs:dos_result], bx
+    dos_clr_cf
+    jmp .h3D_exit
+
+.h3D_no_handles:
+    mov word [cs:dos_result], 0x0004
+    dos_set_cf
+    jmp .h3D_exit
+.h3D_load_error:
+.h3D_too_big:
+    mov word [cs:dos_result], 0x0002
+    dos_set_cf
+.h3D_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=3Eh - Close file. BX = handle. Writes back if modified.
+; ==================================================================
+com_3Eh:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    cmp bx, MAX_HANDLES
+    jae .h3E_error
+    cmp byte [cs:dos_handle_inuse + bx], 0
+    je .h3E_error
+
+    cmp byte [cs:dos_handle_modified + bx], 0
+    je .h3E_no_write
+
+    ; write the handle buffer back to disk
+    ; fs_write_huge_file: AX=filename, BX=size_low, DI=size_high,
+    ;                     CX=src_offset, DX=src_segment
+    push ds
+    push es
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    ; AX = name pointer
+    mov si, dos_handle_name
+    mov ax, bx
+    shl ax, 4
+    add si, ax
+    mov ax, si
+    ; DX = handle buffer segment
+    mov dx, bx
+    shl dx, 10
+    add dx, HANDLE_BUF_SEG
+    ; BX = size_low
+    push ax
+    mov ax, bx
+    shl ax, 1
+    mov si, ax
+    mov bx, [cs:dos_handle_size + si]
+    pop ax
+    xor di, di                     ; size_high = 0
+    xor cx, cx                     ; source offset = 0
+    call fs_write_huge_file
+    pop es
+    pop ds
+    jc .h3E_write_error
+
+.h3E_no_write:
+    mov byte [cs:dos_handle_inuse + bx], 0
+    mov word [cs:dos_result], 0
+    dos_clr_cf
+    jmp .h3E_exit
+
+.h3E_write_error:
+.h3E_error:
+    mov word [cs:dos_result], 0x0006
+    dos_set_cf
+.h3E_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=3Fh - Read from file. BX = handle, CX = count, DS:DX = buffer.
+; OUT: AX = bytes read (0 at EOF).
+; ==================================================================
+com_3Fh:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    mov [cs:dos_caller_ds], ds
+
+    cmp bx, MAX_HANDLES
+    jae .h3F_error
+    cmp byte [cs:dos_handle_inuse + bx], 0
+    je .h3F_error
+
+    ; word-array byte index in DI, handle segment in SI
+    mov di, bx
+    shl di, 1
+    mov si, bx
+    shl si, 10
+    add si, HANDLE_BUF_SEG
+
+    ; available = size - position
+    mov ax, [cs:dos_handle_size + di]
+    sub ax, [cs:dos_handle_pos + di]
+    jbe .h3F_zero
+    cmp cx, ax
+    jbe .h3F_count_ok
+    mov cx, ax
+.h3F_count_ok:
+    mov ax, cx                     ; bytes to transfer (CX is consumed by movsb)
+    mov di, [cs:dos_handle_pos + di]      ; source offset
+
+    push es
+    mov es, si                           ; ES = handle buffer (source)
+    push ds
+    mov ds, [cs:dos_caller_ds]           ; DS = caller (dest)
+    mov si, dx                           ; dest offset
+    mov cx, ax
+    rep movsb
+    pop ds
+    pop es
+
+    ; advance position (DI holds the byte index again)
+    mov di, bx
+    shl di, 1
+    add [cs:dos_handle_pos + di], ax
+    mov [cs:dos_result], ax
+    dos_clr_cf
+    jmp .h3F_exit
+.h3F_zero:
+    mov word [cs:dos_result], 0
+    dos_clr_cf
+    jmp .h3F_exit
+.h3F_error:
+    mov word [cs:dos_result], 0x0006
+    dos_set_cf
+.h3F_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=40h - Write to file. BX = handle, CX = count, DS:DX = buffer.
+; OUT: AX = bytes written.
+; ==================================================================
+com_40h:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    mov [cs:dos_caller_ds], ds
+
+    cmp bx, MAX_HANDLES
+    jae .h40_error
+    cmp byte [cs:dos_handle_inuse + bx], 0
+    je .h40_error
+
+    ; word-array byte index in DI, handle segment in SI
+    mov di, bx
+    shl di, 1
+    mov si, bx
+    shl si, 10
+    add si, HANDLE_BUF_SEG
+
+    ; Cap the write so we never overflow the 16 KiB handle buffer.
+    mov ax, HANDLE_BUF_SIZE
+    sub ax, [cs:dos_handle_pos + di]     ; free space from the position
+    jbe .h40_buffer_full
+    cmp cx, ax
+    jbe .h40_count_ok
+    mov cx, ax
+.h40_count_ok:
+    mov ax, cx                     ; bytes to write
+
+    push es
+    mov es, si                           ; ES = handle buffer (dest)
+    push ds
+    mov ds, [cs:dos_caller_ds]           ; DS = caller (source)
+    mov si, dx                           ; source offset
+    mov di, [cs:dos_handle_pos + di]     ; dest offset
+    mov cx, ax
+    rep movsb
+    pop ds
+    pop es
+
+    ; advance position and grow the size if needed
+    mov di, bx
+    shl di, 1
+    add [cs:dos_handle_pos + di], ax
+    mov cx, [cs:dos_handle_pos + di]
+    cmp cx, [cs:dos_handle_size + di]
+    jbe .h40_size_ok
+    mov [cs:dos_handle_size + di], cx
+.h40_size_ok:
+    mov byte [cs:dos_handle_modified + bx], 1
+    mov [cs:dos_result], ax
+    dos_clr_cf
+    jmp .h40_exit
+.h40_buffer_full:
+    ; the buffer is full at this position: write 0 bytes
+    mov word [cs:dos_result], 0
+    dos_clr_cf
+    jmp .h40_exit
+.h40_error:
+    mov word [cs:dos_result], 0x0006
+    dos_set_cf
+.h40_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; AH=42h - Seek. BX = handle, CX:DX = offset, AL = origin.
+; OUT: DX:AX = new position.
+; ==================================================================
+com_42h:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push ds
+    push es
+
+    cmp bx, MAX_HANDLES
+    jae .h42_error
+    cmp byte [cs:dos_handle_inuse + bx], 0
+    je .h42_error
+
+    ; only 16-bit offsets are supported (CX must be 0)
+    test cx, cx
+    jnz .h42_error
+
+    mov di, bx
+    shl di, 1
+
+    cmp al, 0
+    je .h42_from_start
+    cmp al, 1
+    je .h42_from_current
+    cmp al, 2
+    je .h42_from_end
+    jmp .h42_error
+
+.h42_from_start:
+    mov [cs:dos_handle_pos + di], dx
+    jmp .h42_done
+.h42_from_current:
+    add [cs:dos_handle_pos + di], dx
+    jmp .h42_done
+.h42_from_end:
+    mov ax, [cs:dos_handle_size + di]
+    add ax, dx
+    mov [cs:dos_handle_pos + di], ax
+.h42_done:
+    mov ax, [cs:dos_handle_pos + di]
+    mov [cs:dos_result], ax
+    xor dx, dx
+    dos_clr_cf
+    jmp .h42_exit
+.h42_error:
+    mov word [cs:dos_result], 0x0006
+    dos_set_cf
+.h42_exit:
+    pop es
+    pop ds
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret

--- a/src/kernel/features/exe/exe.asm
+++ b/src/kernel/features/exe/exe.asm
@@ -26,6 +26,14 @@ MZ_OVERLAY_NUM      equ 0x1A
 ; EXE_EXECUTE - Loads and executes an MZ EXE file
 ; IN : AX = pointer to filename (ASCIIZ, in DS=KERNEL_DATA_SEG)
 ; OUT : CF = 1 on error
+<<<<<<< HEAD
+=======
+;
+; The MZ header is validated before execution: signature, overlay number,
+; header size, computed image size (page_count/last_page_bytes), relocation
+; table placement and every relocation target are bounded to the loaded
+; image, so a malformed EXE cannot write anywhere in the 1MB space.
+>>>>>>> 88a7da6 (Первый коммит)
 ; =======================================================================
 exe_execute:
     push ax
@@ -43,6 +51,11 @@ exe_execute:
     ret
 
 .loaded:
+<<<<<<< HEAD
+=======
+    mov word [exe_file_size_low], ax
+    mov word [exe_file_size_high], dx
+>>>>>>> 88a7da6 (Первый коммит)
     pop ax
 
     mov ax, EXE_LOAD_SEG
@@ -61,6 +74,39 @@ exe_execute:
     jnz .bad_sig
 
     mov ax, [es:MZ_HEADER_PARAS]
+<<<<<<< HEAD
+=======
+    cmp ax, 0x20
+    jb .bad_sig
+
+    ; image_size = (page_count - 1) * 512 + last_page_bytes
+    mov dx, [es:MZ_PAGE_COUNT]
+    test dx, dx
+    jz .bad_sig
+    mov bx, [es:MZ_LAST_PAGE_BYTES]
+    test bx, bx
+    jnz .last_page_ok
+    mov bx, 512
+.last_page_ok:
+    dec dx
+    mov cx, 512
+    mov ax, dx
+    mul cx
+    add ax, bx
+    adc dx, 0
+    cmp dx, 0
+    jne .bad_sig
+    cmp ax, 0xC000
+    ja .bad_sig
+    mov [exe_image_size], ax
+
+    mov dx, [es:MZ_HEADER_PARAS]
+    shl dx, 4
+    cmp ax, dx
+    jb .bad_sig
+
+    mov ax, [es:MZ_HEADER_PARAS]
+>>>>>>> 88a7da6 (Первый коммит)
     add ax, EXE_LOAD_SEG
     mov [exe_code_seg], ax
 
@@ -78,6 +124,19 @@ exe_execute:
     jz .reloc_done
 
     mov si, [es:MZ_RELOC_TABLE_OFF]
+<<<<<<< HEAD
+=======
+    cmp si, [exe_image_size]
+    jae .bad_sig
+
+    ; Bound reloc count by the space left in the image after the table.
+    mov ax, [exe_image_size]
+    sub ax, si
+    shr ax, 2
+    cmp cx, ax
+    ja .bad_sig
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov bp, [exe_code_seg]
 
 .reloc_loop:
@@ -85,6 +144,24 @@ exe_execute:
     mov dx, [es:si+2]
     add si, 4
 
+<<<<<<< HEAD
+=======
+    ; Validate target: (dx*16 + bx) must be inside the loaded image.
+    push ax
+    push dx
+    mov ax, dx
+    mov cx, 16
+    mul cx
+    add ax, bx
+    adc dx, 0
+    cmp dx, 0
+    jne .reloc_oob
+    cmp ax, [exe_image_size]
+    jae .reloc_oob
+    pop dx
+    pop ax
+
+>>>>>>> 88a7da6 (Первый коммит)
     push es
     mov ax, bp
     add ax, dx
@@ -93,6 +170,15 @@ exe_execute:
     pop es
 
     loop .reloc_loop
+<<<<<<< HEAD
+=======
+    jmp .reloc_done
+
+.reloc_oob:
+    pop dx
+    pop ax
+    jmp .bad_sig
+>>>>>>> 88a7da6 (Первый коммит)
 
 .reloc_done:
     mov ax, KERNEL_DATA_SEG
@@ -105,6 +191,11 @@ exe_execute:
     mov [com_stack_save], sp
     mov [com_ss_save], ss
 
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 2
+
+>>>>>>> 88a7da6 (Первый коммит)
     call api_dos_init
     call DisableMouse
 
@@ -198,4 +289,11 @@ exe_code_seg        dw 0
 exe_init_ss         dw 0
 exe_init_sp         dw 0
 exe_init_ip         dw 0
+<<<<<<< HEAD
 exe_init_cs         dw 0
+=======
+exe_init_cs         dw 0
+exe_file_size_low       dw 0
+exe_file_size_high      dw 0
+exe_image_size          dw 0
+>>>>>>> 88a7da6 (Первый коммит)

--- a/src/kernel/features/fault_handlers.asm
+++ b/src/kernel/features/fault_handlers.asm
@@ -1,0 +1,236 @@
+; ==================================================================
+; x16-PRos - CPU exception handlers
+; Copyright (C) 2025 PRoX2011
+;
+; Installs handlers for the fault vectors that a crashing program can
+; trigger in REAL MODE. IMPORTANT: vectors 0x08-0x0F are hardware
+; IRQs in real mode (0x08=timer, 0x09=keyboard, 0x0E=floppy), so we
+; only hook vectors that are pure CPU exceptions in real mode:
+;   #DE (vector 0x00, divide error)
+;   #UD (vector 0x06, invalid opcode)
+;
+; Instead of the machine triple-faulting / rebooting, the fault is
+; reported with the faulting CS:IP and control returns to the shell.
+; A fault inside kernel code (CS = KERNEL_DATA_SEG) or more than
+; MAX_FAULTS consecutive faults halts the machine to avoid an
+; infinite fault loop.
+; ==================================================================
+
+MAX_FAULTS equ 8
+
+fault_ss_save dw 0
+fault_sp_save dw 0
+fault_cs      dw 0
+fault_ip      dw 0
+fault_count   db 0
+
+; ==================================================================
+; INIT_FAULT_HANDLERS - installs the fault vectors and saves the
+; kernel recovery stack. Called once during init.
+; ==================================================================
+init_fault_handlers:
+    push ax
+    push es
+    xor ax, ax
+    mov es, ax
+    cli
+    mov word [es:0x00*4], fault_handler_de
+    mov word [es:0x00*4+2], cs
+    mov word [es:0x06*4], fault_handler_ud
+    mov word [es:0x06*4+2], cs
+    sti
+    mov [fault_ss_save], ss
+    mov [fault_sp_save], sp
+    pop es
+    pop ax
+    ret
+
+fault_handler_de:
+    mov si, .de_msg
+    jmp fault_handler_common
+.de_msg db 'Fault: Divide error (#DE)', 0
+
+fault_handler_ud:
+    mov si, .ud_msg
+    jmp fault_handler_common
+.ud_msg db 'Fault: Invalid opcode (#UD)', 0
+
+fault_handler_gp:
+    mov si, .gp_msg
+    jmp fault_handler_common
+.gp_msg db 'Fault: General protection (#GP)', 0
+
+fault_handler_pf:
+    mov si, .pf_msg
+    jmp fault_handler_common
+.pf_msg db 'Fault: Page fault (#PF)', 0
+
+; ==================================================================
+; FAULT_HANDLER_COMMON - SI = fault message.
+; Entry stack (pushed by the INT n): [SP] = IP, [SP+2] = CS, [SP+4] = FLAGS
+; ==================================================================
+fault_handler_common:
+    mov bp, sp
+    mov ax, [ss:bp]          ; faulting IP
+    mov [fault_ip], ax
+    mov bx, [ss:bp+2]        ; faulting CS
+    mov [fault_cs], bx
+
+    pusha
+    push ds
+    push es
+
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    sti
+
+    ; A fault inside the kernel would only recur; halt in that case.
+    cmp bx, KERNEL_DATA_SEG
+    je .halt_kernel_fault
+
+    inc byte [fault_count]
+    cmp byte [fault_count], MAX_FAULTS
+    jae .halt_kernel_fault
+
+    call print_string_red
+    call print_newline
+
+    mov si, .at_msg
+    call print_string
+    mov ax, [fault_cs]
+    call print_hex_word
+    mov al, ':'
+    mov bl, COLOR_WHITE
+    call print_char
+    mov ax, [fault_ip]
+    call print_hex_word
+    call print_newline
+    call print_newline
+
+    mov si, .return_msg
+    call print_string_yellow
+    call print_newline
+
+    pop es
+    pop ds
+    popa
+
+    ; Re-establish a sane execution environment.
+    mov byte [current_program_type], 0
+    call fs_reset_floppy
+    call EnableMouse
+    call font_reinstall
+    call load_and_apply_theme
+
+    cli
+    mov ss, [fault_ss_save]
+    mov sp, [fault_sp_save]
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    sti
+
+    jmp get_cmd
+
+.halt_kernel_fault:
+    mov si, .kernel_fault_msg
+    call print_string_red
+    call print_newline
+    mov si, .at_msg
+    call print_string
+    mov ax, [fault_cs]
+    call print_hex_word
+    mov al, ':'
+    mov bl, COLOR_WHITE
+    call print_char
+    mov ax, [fault_ip]
+    call print_hex_word
+    call print_newline
+    cli
+    hlt
+    jmp $
+
+.at_msg          db '  at ', 0
+.return_msg      db 'Program terminated. Returning to shell...', 0
+.kernel_fault_msg db 'Kernel fault - system halted', 0
+
+; ==================================================================
+; ABORT_PROGRAM_TO_SHELL - Ctrl+Shift+F1 was pressed while a program
+; was running. Abandons the program's context and returns to the
+; shell. Called from check_abort_hotkey (INT 0x16 hook) or the
+; INT 0x1C timer hook.
+; IN : AL = previous program type (1 = BIN/PLE, 2 = COM/EXE)
+; OUT: never returns (jumps to get_cmd)
+; ==================================================================
+abort_program_to_shell:
+    mov dl, al                  ; remember the program type
+    cli
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov byte [current_program_type], 0
+    mov ss, [fault_ss_save]
+    mov sp, [fault_sp_save]
+    sti
+
+    mov si, .msg
+    call print_string_yellow
+    call print_newline
+
+    ; COM/EXE programs install the DOS INT 0x21 hook; remove it.
+    cmp dl, 2
+    jne .no_ivt
+    push es
+    push si
+    push di
+    push cx
+    xor ax, ax
+    mov es, ax
+    mov si, saved_interrupt_table
+    xor di, di
+    mov cx, 512
+    rep movsw
+    pop cx
+    pop di
+    pop si
+    pop es
+.no_ivt:
+
+    call fs_reset_floppy
+    call EnableMouse
+    call font_reinstall
+    call load_and_apply_theme
+    call api_output_init
+
+    jmp get_cmd
+.msg db 'Program aborted. Returning to shell...', 0
+
+; ==================================================================
+; PRINT_HEX_WORD - prints AX as 4 hex digits (no prefix).
+; ==================================================================
+print_hex_word:
+    push ax
+    push bx
+    push cx
+    push di
+    mov cx, 4
+    mov di, .hex_buf + 3
+.hex_loop:
+    mov bx, ax
+    and bx, 0x000F
+    mov dl, [.hex_chars + bx]
+    mov [di], dl
+    dec di
+    shr ax, 4
+    loop .hex_loop
+    mov si, .hex_buf
+    call print_string
+    pop di
+    pop cx
+    pop bx
+    pop ax
+    ret
+
+.hex_chars db '0123456789ABCDEF'
+.hex_buf times 5 db 0

--- a/src/kernel/features/fs.asm
+++ b/src/kernel/features/fs.asm
@@ -489,7 +489,32 @@ fs_load_file:
 ; FS_LOAD_HUGE_FILE - Loads a large file across segment boundaries
 ; IN : AX = file name, CX = load offset address, DX = load segment address
 ; OUT : DX:AX = file size (DX=High, AX=Low), CF = error flag
+<<<<<<< HEAD
 ; ========================================================================
+=======
+;
+; Destination guard: loads that would write into the kernel segment
+; (physical 0x20000..0x2FC00) or into VGA/ROM (>= 0xA0000) are rejected
+; with CF=1 instead of silently corrupting the running system.
+; ========================================================================
+%macro FS_CHECK_DEST 0
+    mov ax, [.huge_segment]
+    mov dx, 16
+    mul dx
+    add ax, [.huge_offset]
+    adc dx, 0
+    cmp dx, 0x0A
+    jae .error_exit          ; physical >= 0xA0000 (VGA/ROM)
+    cmp dx, 0x02
+    jb %%ok                  ; physical < 0x20000
+    jne %%ok                 ; physical >= 0x30000
+    cmp ax, 0xFC00
+    jae %%ok                 ; physical >= 0x2FC00 (COM region)
+    jmp .error_exit          ; physical in kernel range [0x20000, 0x2FC00)
+%%ok:
+%endmacro
+
+>>>>>>> 88a7da6 (Первый коммит)
 fs_load_huge_file:
     push bx
     push cx
@@ -662,6 +687,11 @@ fs_load_huge_file:
     mov word [.chain_idx], 0
 
 .load_chain_loop:
+<<<<<<< HEAD
+=======
+    FS_CHECK_DEST
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov si, .chain_buf
     add si, [.chain_idx]
     mov ax, [si]
@@ -712,6 +742,10 @@ fs_load_huge_file:
     add word [.huge_segment], 0x1000
 
 .chain_no_wrap:
+<<<<<<< HEAD
+=======
+    FS_CHECK_DEST
+>>>>>>> 88a7da6 (Первый коммит)
     add word [.chain_idx], 2
     mov ax, [.chain_idx]
     shr ax, 1
@@ -745,6 +779,11 @@ fs_load_huge_file:
     mov [.huge_cluster], ax
 
 .direct_load_loop:
+<<<<<<< HEAD
+=======
+    FS_CHECK_DEST
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov ax, word [.huge_cluster]
     add ax, 31
     call fs_convert_l2hts
@@ -792,6 +831,11 @@ fs_load_huge_file:
     add word [.huge_segment], 0x1000
 
 .direct_check_next:
+<<<<<<< HEAD
+=======
+    FS_CHECK_DEST
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov ax, [.huge_cluster]
     call fs_fat12_cluster_offset
     mov si, disk_buffer
@@ -969,6 +1013,11 @@ fs_write_huge_file:
     jz .wh_free_odd
 .wh_next_even:
     inc bx
+<<<<<<< HEAD
+=======
+    cmp bx, 2847
+    jae .wh_error
+>>>>>>> 88a7da6 (Первый коммит)
     jmp .wh_find_free
 
 .wh_free_even:
@@ -1295,6 +1344,10 @@ fs_write_file:
     mov word [.location], bx
     mov word [.filename], ax
 
+<<<<<<< HEAD
+=======
+    mov ax, [.filename]
+>>>>>>> 88a7da6 (Первый коммит)
     call fs_file_exists
     jc .create_new_file
 
@@ -1355,8 +1408,18 @@ fs_write_file:
     jz .found_free_odd
 .more_even:
     inc bx
+<<<<<<< HEAD
     jmp .find_free_cluster
 
+=======
+    cmp bx, 2847
+    jae .disk_full
+    jmp .find_free_cluster
+
+.disk_full:
+    jmp .failure
+
+>>>>>>> 88a7da6 (Первый коммит)
 .found_free_even:
     push si
     mov si, .free_clusters
@@ -2482,6 +2545,11 @@ fs_create_directory:
     and ax, 0FFFh
     jz .found_free_cluster
     inc bx
+<<<<<<< HEAD
+=======
+    cmp bx, 2847
+    jae .failure
+>>>>>>> 88a7da6 (Первый коммит)
     jmp .find_free_cluster
 
 .found_free_cluster:

--- a/src/kernel/features/keyboard_layout.asm
+++ b/src/kernel/features/keyboard_layout.asm
@@ -1,0 +1,358 @@
+; ==================================================================
+; x16-PRos - Keyboard layout support (EN / RU) and program abort
+; Copyright (C) 2025 PRoX2011
+;
+; INT 0x16 hook: translates the returned character to the active
+; layout (0 = EN, 1 = RU, CP866). Ctrl+Shift toggles the layout.
+; The hook chains to the BIOS handler (the standard TSR technique).
+;
+; Program abort: while a BIN/COM/EXE/PLE program runs, Ctrl+Shift+F1
+; aborts it and returns to the shell. The check runs on the BIOS
+; timer tick (INT 0x1C) so it works even while a game is busy-looping
+; and never calls INT 0x16.
+; ==================================================================
+
+keyboard_layout db 0          ; 0 = EN, 1 = RU
+old_int16_vector dd 0         ; far pointer to the previous INT 0x16 handler
+
+; ==================================================================
+; INIT_KEYBOARD_LAYOUT - saves the old INT 0x16 vector, installs the
+; translation handler, and hooks INT 0x1C for the abort hotkey.
+; Called once during init.
+; ==================================================================
+init_keyboard_layout:
+    push ax
+    push es
+    xor ax, ax
+    mov es, ax
+    cli
+    mov ax, [es:0x16*4]
+    mov word [old_int16_vector], ax
+    mov ax, [es:0x16*4+2]
+    mov word [old_int16_vector+2], ax
+    mov word [es:0x16*4], int16_handler
+    mov word [es:0x16*4+2], cs
+    mov word [es:0x1C*4], int1c_abort_check
+    mov word [es:0x1C*4+2], cs
+    sti
+    pop es
+    pop ax
+    ret
+
+; ==================================================================
+; SET_KEYBOARD_LAYOUT - set layout (AL = 0 EN, 1 RU)
+; ==================================================================
+set_keyboard_layout:
+    mov [keyboard_layout], al
+    ret
+
+; ==================================================================
+; INT 0x16 handler
+; ==================================================================
+int16_handler:
+    push ax
+    push bx
+    push cx
+    push dx
+    push si
+    push di
+    push bp
+    push ds
+    push es
+
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+
+    cmp ah, 0x00
+    je .read_key
+    cmp ah, 0x10
+    je .read_key
+    cmp ah, 0x01
+    je .peek_key
+    cmp ah, 0x11
+    je .peek_key
+    jmp .old_handler
+
+.old_handler:
+    pop es
+    pop ds
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    pushf
+    call far [cs:old_int16_vector]
+    iret
+
+.read_key:
+    mov byte [.func_ah], ah
+    call .call_old_handler
+    call check_abort_hotkey
+    call translate_key
+    mov bp, sp
+    mov [bp+16], ax
+    jmp .handler_return
+
+.peek_key:
+    mov byte [.func_ah], ah
+    call .call_old_handler
+    jz .peek_no_key
+    call check_abort_hotkey
+    call translate_key
+    mov bp, sp
+    mov [bp+16], ax
+    and word [bp+22], 0xFFBF    ; clear ZF in the caller's saved flags
+    jmp .handler_return
+.peek_no_key:
+    mov bp, sp
+    or word [bp+22], 0x0040     ; set ZF in the caller's saved flags
+    jmp .handler_return
+
+.handler_return:
+    pop es
+    pop ds
+    pop bp
+    pop di
+    pop si
+    pop dx
+    pop cx
+    pop bx
+    pop ax
+    iret
+
+.call_old_handler:
+    mov ah, [.func_ah]
+    pushf
+    call far [cs:old_int16_vector]
+    ret
+
+.func_ah db 0
+
+; ==================================================================
+; CHECK_ABORT_HOTKEY - Ctrl+Shift+F1 during a running program aborts
+; it and returns to the shell. Called from the INT 0x16 hook after
+; the BIOS handler returns a key, so the hotkey is caught BEFORE the
+; running program receives it.
+; IN : AX = key (AH = scancode).
+; OUT: returns normally, or jumps to abort_program_to_shell.
+; ==================================================================
+check_abort_hotkey:
+    ; The old INT 0x16 handler does not preserve DS.
+    push ax
+    push es
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    mov es, ax
+    cmp byte [current_program_type], 0
+    je .chk_done
+    cmp ah, 0x3B                ; F1 scancode
+    jne .chk_done
+    mov ax, 0x0040
+    mov es, ax
+    mov bl, [es:0x17]           ; keyboard flags byte 1
+    test bl, 0x04               ; Ctrl
+    jz .chk_done
+    test bl, 0x03               ; Shift (left or right)
+    jz .chk_done
+    mov al, [current_program_type]
+    ; The pushed registers stay on the (abandoned) program stack.
+    jmp abort_program_to_shell
+.chk_done:
+    pop es
+    pop ax
+    ret
+
+; ==================================================================
+; KEYBOARD_READ_KEY - blocking read of one key from the BIOS keyboard
+; buffer (BDA 0x40:0x1A/0x1C). Returns AX = key (AH = scan, AL = char).
+; ==================================================================
+keyboard_read_key:
+    mov ax, 0x0040
+    mov es, ax
+.kr_wait:
+    sti
+    mov si, [es:0x1A]          ; head
+    mov di, [es:0x1C]          ; tail
+    cmp si, di
+    je .kr_wait
+    mov ax, [es:si]
+    add si, 2
+    cmp si, 0x3E
+    jb .kr_ok
+    mov si, 0x1E
+.kr_ok:
+    mov [es:0x1A], si
+    ret
+
+; ==================================================================
+; INT 0x1C timer-tick hook. If a program is running and Ctrl+Shift+F1
+; is pending in the keyboard buffer, the key is consumed and the
+; program is aborted back to the shell.
+; ==================================================================
+int1c_abort_check:
+    push ax
+    push bx
+    push es
+    cmp byte [cs:current_program_type], 0
+    je .done
+    mov ax, 0x0040
+    mov es, ax
+    mov bx, [es:0x1A]          ; buffer head
+    cmp bx, [es:0x1C]          ; buffer tail
+    je .done
+    cmp byte [es:bx+1], 0x3B   ; F1 scancode (high byte of key word)
+    jne .done
+    mov bl, [es:0x17]          ; keyboard flags byte 1
+    test bl, 0x04              ; Ctrl
+    jz .done
+    test bl, 0x03              ; Shift
+    jz .done
+    ; Consume the F1 key from the buffer.
+    mov bx, [es:0x1A]
+    add bx, 2
+    cmp bx, 0x3E
+    jb .adv_ok
+    mov bx, 0x1E
+.adv_ok:
+    mov [es:0x1A], bx
+
+    ; AL = program type, then EOI the master PIC: this hook runs inside
+    ; the BIOS timer INT 8 handler, so the timer IRQ must be acknowledged
+    ; before we abandon that context, otherwise IRQ0 stays pending and the
+    ; system clock stops.
+    mov al, [cs:current_program_type]
+    push ax
+    mov al, 0x20
+    out 0x20, al
+    pop ax
+
+    pop es
+    pop bx
+    pop ax
+    jmp abort_program_to_shell
+.done:
+    pop es
+    pop bx
+    pop ax
+    iret
+
+; ==================================================================
+; TRANSLATE_KEY - translate AX (AL = char, AH = scancode) to the
+; active layout. If the layout is EN, AX is returned unchanged.
+; Ctrl+Shift toggles the layout (the hotkey is consumed).
+; Restores DS/ES to KERNEL_DATA_SEG (the BIOS handler may clobber DS).
+; ==================================================================
+translate_key:
+    push bx
+    push dx
+    push si
+    mov ax, KERNEL_DATA_SEG
+    mov ds, ax
+    cmp byte [keyboard_layout], 0
+    je .tk_out
+
+    mov ax, 0x0040
+    mov es, ax
+
+    ; ---- Hotkey: Ctrl+Shift toggles the layout ----
+    mov bl, [es:0x17]          ; keyboard flags byte 1
+    test bl, 0x04              ; Ctrl
+    jz .tk_do_translate
+    test bl, 0x03              ; Shift (left or right)
+    jz .tk_do_translate
+
+    xor byte [keyboard_layout], 1
+    ; consume the hotkey keypress and fetch the next real key
+    pop si
+    pop dx
+    pop bx
+    call keyboard_read_key
+    jmp translate_key
+
+.tk_do_translate:
+    push ax                    ; save the original key
+    mov dl, ah                 ; dl = scancode
+    mov si, ru_layout_table
+.tk_find:
+    mov al, [si]
+    test al, al
+    jz .tk_not_found
+    cmp al, dl
+    je .tk_found
+    add si, 3
+    jmp .tk_find
+.tk_not_found:
+    pop ax
+    jmp .tk_out
+
+.tk_found:
+    ; Determine case: (Shift pressed) XOR (CapsLock on)
+    mov bl, [es:0x17]
+    mov bh, 0
+    test bl, 0x03
+    jz .tk_no_shift
+    mov bh, 1
+.tk_no_shift:
+    test bl, 0x40
+    jz .tk_case_ready
+    xor bh, 1
+.tk_case_ready:
+    test bh, bh
+    jnz .tk_upper
+    mov al, [si+1]             ; lowercase
+    jmp .tk_store
+.tk_upper:
+    mov al, [si+2]             ; uppercase
+.tk_store:
+    mov ah, dl                 ; keep the scancode
+    pop dx                     ; discard the original key
+.tk_out:
+    pop si
+    pop dx
+    pop bx
+.tk_done:
+    ret
+
+; ==================================================================
+; RU layout table: scancode, lowercase (CP866), uppercase (CP866)
+; ==================================================================
+ru_layout_table:
+    db 0x29, 0xF1, 0xF0    ; `  -> ё / Ё
+    db 0x10, 0xA9, 0x89    ; q  -> й / Й
+    db 0x11, 0xE6, 0x96    ; w  -> ц / Ц
+    db 0x12, 0xE3, 0x93    ; e  -> у / У
+    db 0x13, 0xAA, 0x8A    ; r  -> к / К
+    db 0x14, 0xA5, 0x85    ; t  -> е / Е
+    db 0x15, 0xAD, 0x8D    ; y  -> н / Н
+    db 0x16, 0xA3, 0x83    ; u  -> г / Г
+    db 0x17, 0xE8, 0x98    ; i  -> ш / Ш
+    db 0x18, 0xE9, 0x99    ; o  -> щ / Щ
+    db 0x19, 0xA7, 0x87    ; p  -> з / З
+    db 0x1A, 0xE5, 0x95    ; [  -> х / Х
+    db 0x1B, 0xEA, 0x9A    ; ]  -> ъ / Ъ
+    db 0x1E, 0xE4, 0x94    ; a  -> ф / Ф
+    db 0x1F, 0xEB, 0x9B    ; s  -> ы / Ы
+    db 0x20, 0xA2, 0x82    ; d  -> в / В
+    db 0x21, 0xA0, 0x80    ; f  -> а / А
+    db 0x22, 0xAF, 0x8F    ; g  -> п / П
+    db 0x23, 0xE0, 0x90    ; h  -> р / Р
+    db 0x24, 0xAE, 0x8E    ; j  -> о / О
+    db 0x25, 0xAB, 0x8B    ; k  -> л / Л
+    db 0x26, 0xA4, 0x84    ; l  -> д / Д
+    db 0x27, 0xA6, 0x86    ; ;  -> ж / Ж
+    db 0x28, 0xED, 0x9D    ; '  -> э / Э
+    db 0x2C, 0xEF, 0x9F    ; z  -> я / Я
+    db 0x2D, 0xE7, 0x97    ; x  -> ч / Ч
+    db 0x2E, 0xE1, 0x91    ; c  -> с / С
+    db 0x2F, 0xAC, 0x8C    ; v  -> м / М
+    db 0x30, 0xA8, 0x88    ; b  -> и / И
+    db 0x31, 0xE2, 0x92    ; n  -> т / Т
+    db 0x32, 0xEC, 0x9C    ; m  -> ь / Ь
+    db 0x33, 0xA1, 0x81    ; ,  -> б / Б
+    db 0x34, 0xEE, 0x9E    ; .  -> ю / Ю
+    db 0x35, 0x2E, 0x2E    ; /  -> . / .
+    db 0x00

--- a/src/kernel/features/ple/ple.asm
+++ b/src/kernel/features/ple/ple.asm
@@ -126,6 +126,11 @@ ple_execute:
     mov [com_stack_save], sp
     mov [com_ss_save], ss
 
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 1
+
+>>>>>>> 88a7da6 (Первый коммит)
     call DisableMouse
 
     mov ax, [ple_stack_ss]
@@ -154,6 +159,10 @@ ple_execute:
     mov ax, KERNEL_DATA_SEG
     mov ds, ax
     mov es, ax
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 0
+>>>>>>> 88a7da6 (Первый коммит)
     mov ss, [com_ss_save]
     mov sp, [com_stack_save]
     sti

--- a/src/kernel/features/string.asm
+++ b/src/kernel/features/string.asm
@@ -10,7 +10,11 @@
 
 ; =======================================================================
 ; STRING_GET_CURSOR_POS - Gets current cursor position
+<<<<<<< HEAD
 ; IN  : —
+=======
+; IN  :  - 
+>>>>>>> 88a7da6 (Первый коммит)
 ; OUT : DL = column, DH = row
 ; =======================================================================
 string_get_cursor_pos:
@@ -32,7 +36,11 @@ string_get_cursor_pos:
 ; =======================================================================
 ; STRING_MOVE_CURSOR - Moves cursor to specified position
 ; IN  : DL = column, DH = row
+<<<<<<< HEAD
 ; OUT : —
+=======
+; OUT :  - 
+>>>>>>> 88a7da6 (Первый коммит)
 ; =======================================================================
 string_move_cursor:
     pusha

--- a/src/kernel/init.asm
+++ b/src/kernel/init.asm
@@ -8,6 +8,11 @@ init_system:
     cld
 
     call init_segments
+<<<<<<< HEAD
+=======
+    call init_fault_handlers
+    call init_keyboard_layout
+>>>>>>> 88a7da6 (Первый коммит)
     call init_disks
     call init_timer
     call init_api

--- a/src/kernel/kernel.asm
+++ b/src/kernel/kernel.asm
@@ -53,6 +53,14 @@ PROGRAM_LOAD_OFF     equ 0x8000
 PROGRAM_THUNK_OFF    equ 0x7FF0
 PROGRAM_PARAMS_OFF   equ 0x7F00
 
+<<<<<<< HEAD
+=======
+; Large data files (cat, copy) load here - far from the kernel so that
+; text/data files larger than 32 KiB no longer wrap into segment 0x2000.
+DATA_LOAD_SEG        equ 0x3000
+DATA_LOAD_OFF        equ 0x0000
+
+>>>>>>> 88a7da6 (Первый коммит)
 CFG_SCRATCH_SEG      equ FONT_SEG
 CFG_SCRATCH_OFF      equ 0x1000
 
@@ -357,6 +365,10 @@ print_info:
 shell:
 get_cmd:
     call refresh_prompt
+<<<<<<< HEAD
+=======
+    call append_layout_to_prompt
+>>>>>>> 88a7da6 (Первый коммит)
     mov si, final_prompt
     call print_string
 
@@ -377,6 +389,12 @@ get_cmd:
     mov ax, input
     call string_input_string
 
+<<<<<<< HEAD
+=======
+    ; Input was read successfully - the system is healthy, clear faults.
+    mov byte [fault_count], 0
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov byte [autocomplete_enabled], 0
     call print_newline
     cmp byte [input], 0
@@ -501,6 +519,17 @@ get_cmd:
     call string_string_compare
     jc near list_directory
 
+<<<<<<< HEAD
+=======
+    mov di, ls_string
+    call string_string_compare
+    jc near list_directory
+
+    mov di, pwd_string
+    call string_string_compare
+    jc near pwd_command
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov di, ver_string
     call string_string_compare
     jc near print_ver
@@ -517,6 +546,13 @@ get_cmd:
     call string_string_compare
     jc near cat_file
 
+<<<<<<< HEAD
+=======
+    mov di, type_string
+    call string_string_compare
+    jc near cat_file
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov di, del_string
     call string_string_compare
     jc near del_file
@@ -557,10 +593,24 @@ get_cmd:
     call string_string_compare
     jc near mkdir_command
 
+<<<<<<< HEAD
+=======
+    mov di, md_string
+    call string_string_compare
+    jc near mkdir_command
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov di, deldir_string
     call string_string_compare
     jc near deldir_command
 
+<<<<<<< HEAD
+=======
+    mov di, rd_string
+    call string_string_compare
+    jc near deldir_command
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov di, cd_string
     call string_string_compare
     jc near cd_command
@@ -569,6 +619,13 @@ get_cmd:
     call string_string_compare
     jc near rip_terry
 
+<<<<<<< HEAD
+=======
+    mov di, layout_string
+    call string_string_compare
+    jc near layout_command
+
+>>>>>>> 88a7da6 (Первый коммит)
     mov si, command
     mov di, kernel_file
     call string_string_compare
@@ -973,6 +1030,11 @@ launch_bin_program:
     mov [bin_stack_save], sp
     mov [bin_ss_save], ss
 
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 1
+
+>>>>>>> 88a7da6 (Первый коммит)
     call DisableMouse
 
     ; ---- Build trampoline frame on the (still kernel) stack ----
@@ -997,6 +1059,10 @@ launch_bin_program:
     mov ax, KERNEL_DATA_SEG
     mov ds, ax
     mov es, ax
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 0
+>>>>>>> 88a7da6 (Первый коммит)
     mov ss, [bin_ss_save]
     mov sp, [bin_stack_save]
     sti
@@ -1015,6 +1081,11 @@ execute_com:
     mov [com_stack_save], sp
     mov [com_ss_save], ss
 
+<<<<<<< HEAD
+=======
+    mov byte [current_program_type], 2
+
+>>>>>>> 88a7da6 (Первый коммит)
     call api_dos_init
 
     ; Setup COM program environment
@@ -1071,6 +1142,77 @@ print_ver:
     call print_newline
     jmp get_cmd
 
+<<<<<<< HEAD
+=======
+; ===================== Keyboard Layout Command =====================
+; LAYOUT              - toggle EN/RU
+; LAYOUT EN | LAYOUT RU - set layout explicitly
+layout_command:
+    call print_newline
+    mov word si, [param_list]
+    call string_string_parse
+    test ax, ax
+    jz .layout_toggle
+
+    mov si, ax
+    mov ax, si
+    call string_string_uppercase
+    mov di, .ru_str
+    call string_string_compare
+    jc .layout_set_ru
+    mov si, ax
+    mov di, .en_str
+    call string_string_compare
+    jc .layout_set_en
+
+.layout_toggle:
+    xor byte [keyboard_layout], 1
+    jmp .layout_show
+
+.layout_set_ru:
+    mov byte [keyboard_layout], 1
+    jmp .layout_show
+
+.layout_set_en:
+    mov byte [keyboard_layout], 0
+
+.layout_show:
+    mov si, .msg
+    call print_string
+    cmp byte [keyboard_layout], 0
+    jne .layout_ru
+    mov si, .en_str
+    call print_string_cyan
+    jmp .layout_done
+.layout_ru:
+    mov si, .ru_str
+    call print_string_cyan
+.layout_done:
+    call print_newline
+    call print_newline
+    jmp get_cmd
+
+.msg   db 'Keyboard layout: ', 0
+.en_str db 'EN', 0
+.ru_str db 'RU', 0
+
+; ===================== Print Working Directory =====================
+pwd_command:
+    call print_newline
+    cmp byte [current_directory], 0
+    jne .show_dir
+    mov si, root_str
+    call print_string_cyan
+    call print_newline
+    jmp get_cmd
+.show_dir:
+    mov si, current_directory
+    call print_string_cyan
+    call print_newline
+    jmp get_cmd
+root_str db '/', 0
+
+>>>>>>> 88a7da6 (Первый коммит)
 exit:
     jmp reboot_system
 
@@ -1368,8 +1510,13 @@ cat_file:
     pop ax
     jc .not_found
 
+<<<<<<< HEAD
     mov cx, PROGRAM_LOAD_OFF
     mov dx, PROGRAM_LOAD_SEG
+=======
+    mov cx, DATA_LOAD_OFF
+    mov dx, DATA_LOAD_SEG
+>>>>>>> 88a7da6 (Первый коммит)
 
     call fs_load_huge_file
     jc .load_fail
@@ -1381,8 +1528,13 @@ cat_file:
     or cx, dx
     jz .empty_file
 
+<<<<<<< HEAD
     mov word [.curr_seg], PROGRAM_LOAD_SEG
     mov word [.curr_off], PROGRAM_LOAD_OFF
+=======
+    mov word [.curr_seg], DATA_LOAD_SEG
+    mov word [.curr_off], DATA_LOAD_OFF
+>>>>>>> 88a7da6 (Первый коммит)
     mov word [.line_count], 0
 
 .print_loop:
@@ -1566,15 +1718,25 @@ copy_file:
     call fs_file_exists
     jnc .already_exists
     mov ax, dx
+<<<<<<< HEAD
     mov cx, PROGRAM_LOAD_OFF
     mov dx, PROGRAM_LOAD_SEG
+=======
+    mov cx, DATA_LOAD_OFF
+    mov dx, DATA_LOAD_SEG
+>>>>>>> 88a7da6 (Первый коммит)
     call fs_load_huge_file
     jc .load_fail
     ; DX:AX = file size
     mov bx, ax                  ; size_low
     mov di, dx                  ; size_high
+<<<<<<< HEAD
     mov cx, PROGRAM_LOAD_OFF
     mov dx, PROGRAM_LOAD_SEG
+=======
+    mov cx, DATA_LOAD_OFF
+    mov dx, DATA_LOAD_SEG
+>>>>>>> 88a7da6 (Первый коммит)
     mov word ax, [.tmp]
     call fs_write_huge_file
     jc .write_fail
@@ -1653,8 +1815,16 @@ touch_file:
     jmp get_cmd
 
 .filename_provided:
+<<<<<<< HEAD
     call fs_file_exists
     jnc .already_exists
+=======
+    mov word [.touch_filename], ax
+    mov ax, [.touch_filename]
+    call fs_file_exists
+    jnc .already_exists
+    mov ax, [.touch_filename]
+>>>>>>> 88a7da6 (Первый коммит)
     call fs_create_file
     jc .failure
     mov si, .success_msg
@@ -1676,6 +1846,10 @@ touch_file:
 
 .success_msg db 'File created successfully', 0
 .failure_msg db 'Could not create file - invalid filename or disk error', 0
+<<<<<<< HEAD
+=======
+.touch_filename dw 0
+>>>>>>> 88a7da6 (Первый коммит)
 
 write_file:
     mov word si, [param_list]
@@ -1986,7 +2160,14 @@ cd_command:
     je .comp_end
     stosb
     inc cx
+<<<<<<< HEAD
     jmp .copy_comp
+=======
+    cmp cx, 14
+    jb .copy_comp
+    ; Component too long for the 16-byte buffer - abort cleanly.
+    jmp .cd_rollback_clean
+>>>>>>> 88a7da6 (Первый коммит)
 
 .comp_sep:
     mov byte [di], 0
@@ -2060,6 +2241,11 @@ cd_command:
 
 .cd_rollback:
     pop si                  ; clean remaining path from stack
+<<<<<<< HEAD
+=======
+
+.cd_rollback_clean:
+>>>>>>> 88a7da6 (Первый коммит)
     ; Restore original state
     mov ax, [.saved_cluster]
     mov [current_dir_cluster], ax
@@ -2150,6 +2336,46 @@ rip_terry:
 
 .rip_terry db "Rest in peace Terry A. Devis (1969 - 2018)", 0
 
+<<<<<<< HEAD
+=======
+; ==================================================================
+; APPEND_LAYOUT_TO_PROMPT - appends "[EN] " / "[RU] " to final_prompt
+; so the active keyboard layout is always visible. Skips appending
+; if the prompt is already too long to fit the 64-byte buffer.
+; ==================================================================
+append_layout_to_prompt:
+    pusha
+    mov di, final_prompt
+.find_end:
+    cmp byte [di], 0
+    je .found_end
+    inc di
+    jmp .find_end
+.found_end:
+    mov ax, di
+    sub ax, final_prompt
+    cmp ax, 56
+    ja .done
+    cmp byte [keyboard_layout], 0
+    jne .tag_ru
+    mov si, .en_tag
+    jmp .copy_tag
+.tag_ru:
+    mov si, .ru_tag
+.copy_tag:
+    lodsb
+    test al, al
+    jz .done
+    stosb
+    jmp .copy_tag
+.done:
+    popa
+    ret
+
+.en_tag db '[EN] ', 0
+.ru_tag db '[RU] ', 0
+
+>>>>>>> 88a7da6 (Первый коммит)
 %INCLUDE "src/kernel/init.asm"                      ; x16-PRos initialisation
 %INCLUDE "src/kernel/log.asm"                       ; Log functions
 %INCLUDE "src/kernel/features/fs.asm"               ; FAT12 filesystem functions
@@ -2163,6 +2389,11 @@ rip_terry:
 %INCLUDE "src/kernel/features/exe/exe.asm"          ; MZ EXE
 %INCLUDE "src/kernel/features/ple/ple.asm"          ; PLE
 %INCLUDE "src/kernel/features/cp866.asm"            ; .FNT font loading
+<<<<<<< HEAD
+=======
+%INCLUDE "src/kernel/features/keyboard_layout.asm"  ; EN/RU keyboard layout
+%INCLUDE "src/kernel/features/fault_handlers.asm"   ; CPU exception handlers
+>>>>>>> 88a7da6 (Первый коммит)
 
 ; ====== DRIVERS ======
 %INCLUDE "src/drivers/ps2_mouse.asm"                ; Mouse driver
@@ -2197,9 +2428,19 @@ kshell_comands db 'HELP               - get list of commands', 10, 13
                db 'WRITE  <f> <text>  - write to file', 10, 13
                db 'VIEW   <f> <flags> - view BMP image', 10, 13
                db 'CD     <dir>       - change directory', 10, 13
+<<<<<<< HEAD
                db 'MKDIR  <dir>       - create directory', 10, 13
                db 'DELDIR <dir>       - delete directory', 10, 13
                db 'EXIT               - exit to bootloader', 10, 13, 0
+=======
+                db 'MKDIR  <dir>       - create directory', 10, 13
+                db 'DELDIR <dir>       - delete directory', 10, 13
+                db 'LAYOUT [EN|RU]     - switch keyboard layout', 10, 13
+                db 'PWD                - print working directory', 10, 13
+                db 'LS / MD / RD / TYPE - DOS-style aliases', 10, 13
+                db 'Ctrl+Shift+F1      - close a running program', 10, 13
+                db 'EXIT               - exit to bootloader', 10, 13, 0
+>>>>>>> 88a7da6 (Первый коммит)
 
 ; ------ About OS ------
 info db 10, 13
@@ -2239,6 +2480,15 @@ mkdir_string   db 'MKDIR', 0
 deldir_string  db 'DELDIR', 0
 cd_string      db 'CD', 0
 terry_string   db 'TERRY', 0
+<<<<<<< HEAD
+=======
+layout_string  db 'LAYOUT', 0
+ls_string      db 'LS', 0
+pwd_string     db 'PWD', 0
+md_string      db 'MD', 0
+rd_string      db 'RD', 0
+type_string    db 'TYPE', 0
+>>>>>>> 88a7da6 (Первый коммит)
 
 autocomplete_cmd_table:
     dw exit_string, help_string, info_string, cls_string
@@ -2246,7 +2496,12 @@ autocomplete_cmd_table:
     dw cat_string, del_string, copy_string, ren_string
     dw size_string, shut_string, reboot_string
     dw touch_string, write_string, view_string, mkdir_string
+<<<<<<< HEAD
     dw deldir_string
+=======
+    dw deldir_string, layout_string, ls_string, pwd_string
+    dw md_string, rd_string, type_string
+>>>>>>> 88a7da6 (Первый коммит)
     dw 0
 
 ; ------ Errors ------
@@ -2421,6 +2676,13 @@ bin_stack_save       dw 0
 bin_ss_save          dw 0
 program_seg_runtime  dw program_seg
 
+<<<<<<< HEAD
+=======
+; 0 = shell, 1 = BIN/PLE program, 2 = COM/EXE program.
+; Used by the Ctrl+Alt+Del program abort feature.
+current_program_type db 0
+
+>>>>>>> 88a7da6 (Первый коммит)
 first_boot_value     db '1', 0
 
 kernel_file          db 'KERNEL.BIN', 0

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+FAT12 floppy image builder for x16-PRos (verified approach).
+
+Layout matches exactly what the x16-PRos bootloader expects:
+  sector 0        boot sector (BOOT.BIN)
+  sectors 1-9     FAT #1
+  sectors 10-18   FAT #2
+  sectors 19-32   root directory (224 entries / 14 sectors)
+  sectors 33+     data region (SPC=1)
+
+Usage:
+  build_image.py <image> <src_bin_dir> [placement...]
+    placement := <local_path>:<disk_path>
+    disk_path uses / as separator and may start with / (root).
+    The first component after / is a directory name.
+"""
+
+import sys
+import os
+
+BYTE = 512
+RESERVED = 1
+NFATS = 2
+ROOT_ENTRIES = 224
+TOTAL_SECTORS = 2880
+SPF = 9
+ROOT_SECTORS = ROOT_ENTRIES * 32 // BYTE  # 14
+DATA_START = RESERVED + NFATS * SPF + ROOT_SECTORS  # 33
+MAX_CLUSTERS = TOTAL_SECTORS - DATA_START  # 2847
+
+
+def to_83(name):
+    name = name.upper()
+    if "." in name:
+        base, ext = name.split(".", 1)
+    else:
+        base, ext = name, ""
+    base = (base[:8] + " " * 8)[:8]
+    ext = (ext[:3] + " " * 3)[:3]
+    return (base + ext).encode("ascii")
+
+
+def pack_fat(fat):
+    out = bytearray()
+    for i in range(0, len(fat), 2):
+        e0 = fat[i] & 0xFFF
+        e1 = fat[i + 1] & 0xFFF if i + 1 < len(fat) else 0xFFF
+        out += bytes([e0 & 0xFF, ((e0 >> 8) & 0x0F) | ((e1 & 0x0F) << 4), (e1 >> 4) & 0xFF])
+    return bytes(out[:SPF * BYTE].ljust(SPF * BYTE, b"\0"))
+
+
+def dir_entry(name11, attr, cluster, size):
+    e = bytearray(32)
+    e[0:11] = name11
+    e[11] = attr
+    e[26:28] = bytes([cluster & 0xFF, (cluster >> 8) & 0xFF])
+    e[28:32] = bytes([size & 0xFF, (size >> 8) & 0xFF, (size >> 16) & 0xFF, (size >> 24) & 0xFF])
+    return bytes(e)
+
+
+class Image:
+    def __init__(self):
+        self.data = bytearray(TOTAL_SECTORS * BYTE)
+        self.fat = [0] * (MAX_CLUSTERS + 2)
+        self.fat[0] = 0xFF0
+        self.fat[1] = 0xFFF
+        self.next_cluster = 2
+        self.root_entries = []
+        self.dir_entries = {}   # dir path -> list of 32-byte entries
+        self.dir_cluster = {}   # dir path -> first cluster
+
+    def alloc(self, n):
+        start = self.next_cluster
+        for i in range(n):
+            c = start + i
+            self.fat[c] = (c + 1) if i < n - 1 else 0xFFF
+        self.next_cluster += n
+        if self.next_cluster - 2 > MAX_CLUSTERS:
+            raise RuntimeError("image full")
+        return start
+
+    def add_dir(self, path, parent_cluster=0):
+        cl = self.alloc(1)
+        self.dir_cluster[path] = cl
+        self.dir_entries[path] = [
+            dir_entry(b".          ", 0x10, cl, 0),
+            dir_entry(b"..         ", 0x10, parent_cluster, 0),
+        ]
+        return cl
+
+    def add_file(self, disk_path, data):
+        n = max(1, (len(data) + BYTE - 1) // BYTE)
+        cl = self.alloc(n)
+        # write data
+        for i in range(n):
+            sector = DATA_START + (cl - 2) + i
+            chunk = data[i * BYTE:(i + 1) * BYTE]
+            self.data[sector * BYTE:sector * BYTE + len(chunk)] = chunk
+        entry = dir_entry(to_83(os.path.basename(disk_path)), 0x20, cl, len(data))
+        if "/" not in disk_path:
+            self.root_entries.append(entry)
+        else:
+            parent = disk_path.rsplit("/", 1)[0]
+            self.dir_entries.setdefault(parent, []).append(entry)
+
+    def build(self, boot, out_path):
+        self.data[0:len(boot)] = boot[:BYTE]
+
+        # FATs
+        fatb = pack_fat(self.fat)
+        self.data[1 * BYTE:10 * BYTE] = fatb
+        self.data[10 * BYTE:19 * BYTE] = fatb
+
+        # root directory
+        rootb = b"".join(self.root_entries)
+        rootb = rootb.ljust(ROOT_SECTORS * BYTE, b"\0")
+        self.data[19 * BYTE:33 * BYTE] = rootb[:ROOT_SECTORS * BYTE]
+
+        # subdirectories: write contents to their clusters
+        for path, entries in self.dir_entries.items():
+            cl = self.dir_cluster[path]
+            content = b"".join(entries).ljust(BYTE, b"\0")
+            # a directory may span clusters if it has many entries
+            needed = max(1, (len(b"".join(entries)) + BYTE - 1) // BYTE)
+            content = b"".join(entries).ljust(needed * BYTE, b"\0")
+            for i in range(needed):
+                sector = DATA_START + (cl - 2) + i
+                chunk = content[i * BYTE:(i + 1) * BYTE]
+                self.data[sector * BYTE:sector * BYTE + len(chunk)] = chunk
+
+        with open(out_path, "wb") as f:
+            f.write(self.data)
+        print(f"wrote {out_path} ({os.path.getsize(out_path)} bytes)")
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(__doc__)
+        sys.exit(2)
+    out_path = sys.argv[1]
+    src_bin = sys.argv[2]
+    placements = sys.argv[3:]
+
+    img = Image()
+
+    # register dirs first so their clusters are allocated before files
+    dirs = set()
+    norm = []
+    for placement in placements:
+        local, disk = placement.split(":", 1)
+        while disk.startswith("/"):
+            disk = disk[1:]
+        norm.append(local + ":" + disk)
+        parts = disk.split("/")
+        for i in range(1, len(parts)):
+            dirs.add("/".join(parts[:i]))
+    placements = norm
+
+    for d in sorted(dirs):
+        parent = d.rsplit("/", 1)[0] if "/" in d else ""
+        pc = img.dir_cluster.get(parent, 0)
+        img.add_dir(d, pc)
+        # register the dir itself in the parent directory
+        entry = dir_entry(to_83(os.path.basename(d)), 0x10, img.dir_cluster[d], 0)
+        if parent == "":
+            img.root_entries.append(entry)
+        else:
+            img.dir_entries[parent].append(entry)
+
+    # add files
+    for placement in placements:
+        local, disk = placement.split(":", 1)
+        with open(local, "rb") as f:
+            data = f.read()
+        img.add_file(disk, data)
+
+    with open(os.path.join(src_bin, "BOOT.BIN"), "rb") as f:
+        boot = f.read()
+    img.build(boot, out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build_test.ps1
+++ b/tools/build_test.ps1
@@ -1,0 +1,127 @@
+# x16-PRos test build for Windows (NASM + Python FAT12 builder)
+# Builds bootloader, kernel and all programs, then creates a bootable
+# test floppy image with setup wizard and logo display disabled.
+
+$ErrorActionPreference = "SilentlyContinue"
+$nasmDir = "C:\Users\User\AppData\Local\bin\NASM"
+$env:Path = "$nasmDir;$env:Path"
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+New-Item -ItemType Directory -Force -Path "bin", "disk_img", "build" | Out-Null
+New-Item -ItemType Directory -Force -Path "build\test_conf" | Out-Null
+
+function Invoke-Nasm($src, $out, $inc = $null) {
+    $args = @("-f", "bin")
+    if ($inc) { $args += @("-I", $inc) }
+    $args += @($src, "-o", $out)
+    & nasm @args 2>&1 | ForEach-Object { Write-Host "  $_" }
+    if ($LASTEXITCODE -ne 0) { throw "NASM failed: $src" }
+}
+
+Write-Host "== Compiling bootloader =="
+Invoke-Nasm "src/bootloader/boot.asm" "bin/BOOT.BIN"
+
+Write-Host "== Compiling kernel =="
+Invoke-Nasm "src/kernel/kernel.asm" "bin/KERNEL.BIN"
+$kernelSize = (Get-Item "bin/KERNEL.BIN").Length
+Write-Host "KERNEL.BIN size: $kernelSize bytes (limit 43008, warn 40960)"
+if ($kernelSize -gt 43008) { throw "KERNEL.BIN too large!" }
+
+$programsRoot = @{
+    "programs/autoexec.asm"   = "AUTOEXEC.BIN"
+    "programs/setup/setup.asm" = "SETUP.BIN"
+}
+
+$programsBin = @{
+    "programs/grep.asm"       = "GREP.BIN"
+    "programs/tail.asm"       = "TAIL.BIN"
+    "programs/cpu.asm"        = "CPU.BIN"
+    "programs/dlist.asm"      = "DLIST.BIN"
+    "programs/theme.asm"      = "THEME.BIN"
+    "programs/fetch.asm"      = "FETCH.BIN"
+    "programs/credits.asm"    = "CREDITS.BIN"
+    "programs/write.asm"      = "WRITER.BIN"
+    "programs/barchart.asm"   = "BCHART.BIN"
+    "programs/brainf.asm"     = "BRAINF.BIN"
+    "programs/calc.asm"       = "CALC.BIN"
+    "programs/memory.asm"     = "MEMORY.BIN"
+    "programs/mine.asm"       = "MINE.BIN"
+    "programs/snake.asm"      = "SNAKE.BIN"
+    "programs/space.asm"      = "SPACE.BIN"
+    "programs/procentc.asm"   = "PROCENTC.BIN"
+    "programs/pong.asm"       = "PONG.BIN"
+    "programs/flappy.asm"     = "FLAPPY.BIN"
+    "programs/hexedit.asm"    = "HEXEDIT.BIN"
+    "programs/clock.asm"      = "CLOCK.BIN"
+    "programs/tetris.asm"     = "TETRIS.BIN"
+    "programs/chars.asm"      = "CHARS.BIN"
+    "programs/eye.asm"        = "EYE.BIN"
+    "programs/ed.asm"         = "ED.BIN"
+    "programs/font.asm"       = "FONT.BIN"
+    "programs/tree.asm"       = "TREE.BIN"
+    "programs/print.asm"      = "PRINT.BIN"
+    "programs/calendar.asm"   = "CALENDAR.BIN"
+    "programs/dump.asm"       = "DUMP.BIN"
+    "programs/uptime.asm"     = "UPTIME.BIN"
+}
+
+Write-Host "== Compiling programs =="
+$all = @{}
+foreach ($k in $programsRoot.Keys) { $all[$k] = $programsRoot[$k] }
+foreach ($k in $programsBin.Keys) { $all[$k] = $programsBin[$k] }
+foreach ($src in $all.Keys) {
+    $out = "bin/$($all[$src])"
+    if (Test-Path $src) {
+        Invoke-Nasm $src $out
+        Write-Host "  $src -> $out"
+    } else {
+        Write-Host "  SKIP (missing): $src"
+    }
+}
+
+Write-Host "== Creating test configs =="
+Set-Content -Path "build/test_conf/FIRST_B.CFG" -Value "0" -NoNewline
+Set-Content -Path "build/test_conf/SYSTEM.CFG" -Value @(
+    "# x16-PRos System Configuration (test build)",
+    "LOGO=FALSE",
+    "LOGO_STRETCH=FALSE",
+    "START_SOUND=FALSE"
+) -Encoding ASCII
+Copy-Item "src/kernel/configs/USER.CFG" "build/test_conf/USER.CFG"
+Copy-Item "src/kernel/configs/PASSWORD.CFG" "build/test_conf/PASSWORD.CFG"
+Copy-Item "src/kernel/configs/TIMEZONE.CFG" "build/test_conf/TIMEZONE.CFG"
+Copy-Item "src/kernel/configs/PROMPT.CFG" "build/test_conf/PROMPT.CFG"
+Copy-Item "src/kernel/configs/THEME.CFG" "build/test_conf/THEME.CFG"
+Copy-Item "src/kernel/configs/FONT.CFG" "build/test_conf/FONT.CFG"
+
+Write-Host "== Building image =="
+$placements = @(
+    "bin/KERNEL.BIN:/KERNEL.BIN"
+    "bin/AUTOEXEC.BIN:/AUTOEXEC.BIN"
+    "bin/SETUP.BIN:/SETUP.BIN"
+    "build/test_conf/SYSTEM.CFG:/SYSTEM.CFG"
+    "assets/fonts/DEFAULT.FNT:/FONTS.DIR/DEFAULT.FNT"
+    "assets/fonts/BOLD.FNT:/FONTS.DIR/BOLD.FNT"
+    "assets/fonts/THIN.FNT:/FONTS.DIR/THIN.FNT"
+    "assets/fonts/ITALIC.FNT:/FONTS.DIR/ITALIC.FNT"
+    "assets/themes/DEFAULT.THM:/THEMES.DIR/DEFAULT.THM"
+    "build/test_conf/USER.CFG:/CONF.DIR/USER.CFG"
+    "build/test_conf/FIRST_B.CFG:/CONF.DIR/FIRST_B.CFG"
+    "build/test_conf/PASSWORD.CFG:/CONF.DIR/PASSWORD.CFG"
+    "build/test_conf/TIMEZONE.CFG:/CONF.DIR/TIMEZONE.CFG"
+    "build/test_conf/PROMPT.CFG:/CONF.DIR/PROMPT.CFG"
+    "build/test_conf/THEME.CFG:/CONF.DIR/THEME.CFG"
+    "build/test_conf/FONT.CFG:/CONF.DIR/FONT.CFG"
+)
+foreach ($k in $all.Keys) {
+    if (Test-Path $k) { $placements += "bin/$($all[$k]):/BIN.DIR/$($all[$k])" }
+}
+$placements += "src/txt/README.TXT:/DOCS.DIR/README.TXT"
+
+python tools/build_image.py disk_img/x16pros.img bin @placements
+if ($LASTEXITCODE -ne 0) { throw "Image build failed" }
+
+Write-Host "== Build complete =="
+Write-Host "disk_img/x16pros.img ready for QEMU"


### PR DESCRIPTION
What's been done

1. Critical kernel bugs fixed

· EXE loader now validates MZ headers and relocations — malformed EXEs can no longer overwrite arbitrary memory.
· Files >32 KB are safely loaded into segment 0x3000 (preventing writes to kernel/VGA).
· Free cluster search is capped at 2847 — returns an error instead of hanging.
· Vector 0x0E (IRQ6/floppy) no longer overwritten by exception handler.
· int20_handler now properly prints program termination messages.
· API buffers limited to 63 bytes; long cd paths safely roll back.

2. Stability and fault tolerance

· Exception handlers [#DE](https://vk.ru/im/convo/489235012?search=%23DE&entrypoint=unknown)/[#UD](https://vk.ru/im/convo/489235012?search=%23UD&entrypoint=unknown): program crash → CS:IP dump → return to shell (no reboot). Kernel panic → diagnostic HALT.
· Force-close any program: Ctrl+Shift+F1 (hooked via INT 16h + backup INT 1Ch).
· Root directory corruption prevented (fixed double name conversion in fs_create_file/fs_write_file/fs_remove_file).
· touch/write file creation fixed (preserve filename before call).

3. New features

· EN/RU keyboard layout (YCUKEN, CP866) — toggle with Ctrl+Shift, [RU] indicator in prompt.
· DOS compatibility — file descriptor support via INT 0x21 (3Ch, 3Dh, 3Eh, 3Fh, 40h, 42h, 2Eh, 43h, 56h). DOS programs can now create, open, read, write, and seek files.
· New commands: PWD, LS, MD, RD, TYPE.
· New programs: DUMP.BIN (hex dump), UPTIME.BIN (system uptime).
· Fixed programs: procentc (division by zero), tetris (hang), mine (stack imbalance), pong/memory/snake (exit to shell instead of reboot), snake (port 0x60), imfplay (load into 0x3000), tbasic (stack near IVT), calendar (Zeller formula), brainf (Enter in buffer), fetch (duplicate start).
· FLAPPY — added to the build.

4. Infrastructure

· Build and test scripts for Windows: tools/[build_image.py](https://build_image.py/), build_test.ps1, [qemu_test.py](https://qemu_test.py/).
· [ASM_DEV_SKILL.md](https://asm_dev_skill.md/) in root — memory map, ABI, crash patterns, error retrospective.
Final state

· Kernel size: 36,998 bytes (limit 43,008).
· All 35 image files compile; image is clean.
· touch/write create files; dir/layout/uptime/dump work.
· Known issue (not included in build): programs/tbasic.asm fails to assemble due to a buffer declaration error. Can fix separately upon request.